### PR TITLE
Fix vehicle hit zones when repairing vehicles

### DIFF
--- a/Scripts/Game/GameMode/Managers/OVT_VehicleManagerComponent.c
+++ b/Scripts/Game/GameMode/Managers/OVT_VehicleManagerComponent.c
@@ -223,6 +223,7 @@ class OVT_VehicleManagerComponent: OVT_OwnerManagerComponent
 		SCR_VehicleDamageManagerComponent dmg = SCR_VehicleDamageManagerComponent.Cast(entity.FindComponent(SCR_VehicleDamageManagerComponent));
 		if(dmg)
 		{
+			dmg.FullHeal();
 			dmg.SetHealthScaled(dmg.GetMaxHealth());
 		}		
 	}


### PR DESCRIPTION
Vehicles have hit zones that can get damaged independently from their total health (e.g., flat tires, engine, transmission, etc.). This changes the `RepairVehicle` function to ensure that hit zones are fully repaired.

Tested using the test world, shot out the tire of the UAZ, spawned a vehicle maintenance building, and confirmed that the repair menu resulted in the flat being fixed.