### PR TITLE
Workarounds for invalid faction indices in save

### DIFF
--- a/Scripts/Game/GameMode/Persistence/Components/OVT_OccupyingFactionSaveData.c
+++ b/Scripts/Game/GameMode/Persistence/Components/OVT_OccupyingFactionSaveData.c
@@ -74,6 +74,11 @@ class OVT_OccupyingFactionSaveData : EPF_ComponentSaveData
 		{
 			OVT_BaseData existing = of.GetNearestBase(base.location);
 			if(!existing) continue;
+			if (base.faction < 0)
+			{
+				Print("Uninitialized faction found for base, setting to default.", LogLevel.WARNING);
+				base.faction = OVT_Global().GetConfig().GetOccupyingFactionIndex();
+			}
 			existing.faction = base.faction;
 			existing.upgrades = base.upgrades;
 			existing.slotsFilled = base.slotsFilled;

--- a/Scripts/Game/GameMode/Persistence/Components/OVT_ResistanceSaveData.c
+++ b/Scripts/Game/GameMode/Persistence/Components/OVT_ResistanceSaveData.c
@@ -34,20 +34,32 @@ class OVT_ResistanceSaveData : EPF_ComponentSaveData
 		
 		return EPF_EReadResult.OK;
 	}
-	
+
 	override EPF_EApplyResult ApplyTo(IEntity owner, GenericComponent component, EPF_ComponentSaveDataClass attributes)
 	{
 		OVT_ResistanceFactionManager resistance = OVT_ResistanceFactionManager.Cast(component);
-				
+
+		if (m_sPlayerFactionKey.IsEmpty())
+		{
+			Print("Player faction key is invalid, setting to FIA", LogLevel.WARNING);
+			m_sPlayerFactionKey = "FIA";
+		}
+
 		OVT_Global.GetConfig().m_sPlayerFaction = m_sPlayerFactionKey;
-		OVT_Global.GetConfig().m_iPlayerFactionIndex = GetGame().GetFactionManager().GetFactionIndex(GetGame().GetFactionManager().GetFactionByKey(m_sPlayerFactionKey));
-		
+		int playerFactionIndex  = GetGame().GetFactionManager().GetFactionIndex(GetGame().GetFactionManager().GetFactionByKey(m_sPlayerFactionKey));
+		OVT_Global.GetConfig().m_iPlayerFactionIndex = playerFactionIndex;
+
 		foreach(OVT_FOBData fob : m_FOBs)
 		{	
-			fob.id = resistance.m_FOBs.Count();		
-			resistance.m_FOBs.Insert(fob);						
+			fob.id = resistance.m_FOBs.Count();
+			if (fob.faction < 0)
+			{
+				Print(string.Format("FOB with invalid owner faction index found, setting to default of %1", playerFactionIndex), LogLevel.WARNING);
+				fob.faction = playerFactionIndex;
+			}
+			resistance.m_FOBs.Insert(fob);
 		}
-				
+
 		return EPF_EApplyResult.OK;
 	}
 }


### PR DESCRIPTION
If base or FOB factions are ever set to -1 in the save file, reset them with defaults instead.

If the default resistance faction key string is ever empty, set it to `"FIA"`.