### PR TITLE
Fix Building RPL Components

### DIFF
--- a/Prefabs/Structures/Commercial/FuelStations/FuelStation_E_01_building.et
+++ b/Prefabs/Structures/Commercial/FuelStations/FuelStation_E_01_building.et
@@ -5,18 +5,19 @@ SCR_DestructibleBuildingEntity : "{D2A960D237D786F5}Prefabs/Structures/Commercia
    m_aParkingSpots {
     OVT_ParkingPointInfo "{59D030D1D24EF732}" {
      Offset -4.392 0 7.648
-     m_vPosition -4.392 0 7.648
      m_Type PARKING_CAR
     }
     OVT_ParkingPointInfo "{59D030D1B5AAF761}" {
      Offset 12.998 0 4.827
-     m_vPosition 12.998 0 4.827
      m_Type PARKING_CAR
     }
    }
   }
   OVT_ShopComponent "{5996803956C49D1E}" {
    m_ShopType SHOP_VEHICLE
+  }
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
   }
  }
  {

--- a/Prefabs/Structures/Commercial/Shops/ShopHouse_E_2I01t_Base.et
+++ b/Prefabs/Structures/Commercial/Shops/ShopHouse_E_2I01t_Base.et
@@ -4,5 +4,8 @@ SCR_DestructibleBuildingEntity : "{A43A100E3C377DB2}Prefabs/Structures/Core/Buil
   OVT_ShopComponent "{59C2C703C4E7DE6E}" {
    m_ShopType SHOP_GENERAL
   }
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
+  }
  }
 }

--- a/Prefabs/Structures/Commercial/Shops/ShopModern_E_01.et
+++ b/Prefabs/Structures/Commercial/Shops/ShopModern_E_01.et
@@ -4,5 +4,8 @@ SCR_DestructibleBuildingEntity : "{9ABD5AF92E43D2AA}Prefabs/Structures/Commercia
   OVT_ShopComponent "{598EDB5A1677FEA3}" {
    m_ShopType SHOP_GENERAL
   }
- } 
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
+  }
+ }
 }

--- a/Prefabs/Structures/Houses/Village/House_Mountain_E_1I01.et
+++ b/Prefabs/Structures/Houses/Village/House_Mountain_E_1I01.et
@@ -13,7 +13,9 @@ SCR_DestructibleBuildingEntity : "{79CE8730C95EFD23}Prefabs/Structures/Houses/Vi
    m_vPoint PointInfo "{5F026405A5F41BD9}" {
     Offset 1.0792 0 -0.1898
    }
-   m_vPosition -0.376 0 1.314
+  }
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
   }
  }
 }

--- a/Prefabs/Structures/Houses/Village/House_Village_E_1I04/House_Village_E_1I04t.et
+++ b/Prefabs/Structures/Houses/Village/House_Village_E_1I04/House_Village_E_1I04t.et
@@ -14,6 +14,9 @@ SCR_DestructibleBuildingEntity : "{578B698AE1F03DE9}Prefabs/Structures/Houses/Vi
     Offset -8.0011 0.107 0.0925
    }
   }
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
+  }
  }
  coords -0.002 0 0
 }

--- a/Prefabs/Structures/Houses/Village/House_Village_E_1I05/House_Village_E_1I05s.et
+++ b/Prefabs/Structures/Houses/Village/House_Village_E_1I05/House_Village_E_1I05s.et
@@ -13,7 +13,9 @@ SCR_DestructibleBuildingEntity : "{3F0D1AD613E9785F}Prefabs/Structures/Houses/Vi
    m_vPoint PointInfo "{5F026405AC2186F4}" {
     Offset -0.1079 0.5 2.5614
    }
-   m_vPosition 1.169 0.5 -2.355
+  }
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
   }
  }
 }

--- a/Prefabs/Structures/Houses/Village/House_Village_E_1I05/House_Village_E_1I05t.et
+++ b/Prefabs/Structures/Houses/Village/House_Village_E_1I05/House_Village_E_1I05t.et
@@ -14,5 +14,8 @@ SCR_DestructibleBuildingEntity : "{3F0D1AD613E9785F}Prefabs/Structures/Houses/Vi
     Offset -2.0261 0.4954 3.3734
    }
   }
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
+  }
  }
 }

--- a/Prefabs/Structures/Houses/Village/House_Village_E_1L02/House_Village_E_1L02t.et
+++ b/Prefabs/Structures/Houses/Village/House_Village_E_1L02/House_Village_E_1L02t.et
@@ -14,5 +14,8 @@ SCR_DestructibleBuildingEntity : "{58A839659867372C}Prefabs/Structures/Houses/Vi
     Offset 7.5406 0.3419 -2.1801
    }
   }
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
+  }
  }
 }

--- a/Prefabs/Structures/Houses/Village/House_Village_E_1L03/House_Village_E_1L03t.et
+++ b/Prefabs/Structures/Houses/Village/House_Village_E_1L03/House_Village_E_1L03t.et
@@ -13,7 +13,9 @@ SCR_DestructibleBuildingEntity : "{5D5DFAA27335CD9A}Prefabs/Structures/Houses/Vi
    m_vPoint PointInfo "{5F026405BEB3FDF3}" {
     Offset -8.377 0.455 -1.297
    }
-   m_vPosition -8.377 0.455 -1.297
+  }
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
   }
  }
 }

--- a/Prefabs/Structures/Industrial/Garages/Garage_E_02/Garage_E_02.et
+++ b/Prefabs/Structures/Industrial/Garages/Garage_E_02/Garage_E_02.et
@@ -19,20 +19,14 @@ SCR_DestructibleBuildingEntity : "{9D656741EA2AABC5}Prefabs/Structures/Industria
    m_aParkingSpots {
     OVT_ParkingPointInfo "{5D98AC7CB13BA421}" {
      Offset -9.092 0.063 13.989
-     m_vPosition -9.092 0.063 13.989
-     m_vAngles 0 90 0
      m_Type PARKING_CAR
     }
     OVT_ParkingPointInfo "{5D98AC7D6A494BFA}" {
      Offset -2.246 0.063 13.784
-     m_vPosition -2.246 0.063 13.784
-     m_vAngles 0 90 0
      m_Type PARKING_CAR
     }
     OVT_ParkingPointInfo "{5D98AC7D43678293}" {
      Offset 5.855 0.063 13.541
-     m_vPosition 5.855 0.063 13.541
-     m_vAngles 0 90 0
      m_Type PARKING_CAR
     }
    }
@@ -42,6 +36,7 @@ SCR_DestructibleBuildingEntity : "{9D656741EA2AABC5}Prefabs/Structures/Industria
    m_bProcurement 1
   }
   RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
    Streamable Disabled
   }
  }

--- a/Prefabs/Structures/Industrial/Sheds/ShedMetal_02/ShedMetal_02.et
+++ b/Prefabs/Structures/Industrial/Sheds/ShedMetal_02/ShedMetal_02.et
@@ -5,41 +5,36 @@ SCR_DestructibleBuildingEntity : "{EEEBF095E1B611CF}Prefabs/Structures/Industria
    m_aParkingSpots {
     OVT_ParkingPointInfo "{59A550A91F4CF538}" {
      Offset 12.4 0 0
-     m_vPosition 12.4 0 0
      m_Type PARKING_CAR
     }
     OVT_ParkingPointInfo "{59A550A9E7E036B2}" {
      Offset 7.4 0 0
-     m_vPosition 7.4 0 0
      m_Type PARKING_CAR
     }
     OVT_ParkingPointInfo "{59A550A9F0F98D55}" {
      Offset 2.4 0 0
-     m_vPosition 2.4 0 0
      m_Type PARKING_CAR
     }
     OVT_ParkingPointInfo "{59A550A9CF7F3183}" {
      Offset -2.4 0 0
-     m_vPosition -2.4 0 0
      m_Type PARKING_CAR
     }
     OVT_ParkingPointInfo "{59A550A9D59EC77F}" {
      Offset -7.4 0 0
-     m_vPosition -7.4 0 0
      m_Type PARKING_CAR
     }
     OVT_ParkingPointInfo "{59A550A9DF42F005}" {
      Offset -12.4 0 0
-     m_vPosition -12.4 0 0
      m_Type PARKING_CAR
     }
     OVT_ParkingPointInfo "{59A550A98210D9E5}" {
      Offset 0 0 11
      Angles 0 90 0
-     m_vPosition 0 0 11
-     m_vAngles 0 90 0
     }
    }
+  }
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
   }
  }
 }

--- a/Prefabs/Structures/Industrial/Sheds/ShedMetal_02/ShedMetal_02_short.et
+++ b/Prefabs/Structures/Industrial/Sheds/ShedMetal_02/ShedMetal_02_short.et
@@ -5,7 +5,6 @@ SCR_DestructibleBuildingEntity : "{525700C0EC3BA75B}Prefabs/Structures/Industria
    m_aParkingSpots {
     OVT_ParkingPointInfo "{59A6ADD9C2411829}" {
      Offset 5 0 0
-     m_vPosition 5 0 0
      m_Type PARKING_CAR
     }
     OVT_ParkingPointInfo "{59A6ADD9D76EF643}" {
@@ -13,16 +12,16 @@ SCR_DestructibleBuildingEntity : "{525700C0EC3BA75B}Prefabs/Structures/Industria
     }
     OVT_ParkingPointInfo "{59A6ADD9D4AB1A07}" {
      Offset -5 0 0
-     m_vPosition -5 0 0
      m_Type PARKING_CAR
     }
     OVT_ParkingPointInfo "{59A6ADD9DD417D3B}" {
      Offset 0 0 10
      Angles 0 90 0
-     m_vPosition 0 0 10
-     m_vAngles 0 90 0
     }
    }
+  }
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
   }
  }
 }

--- a/Prefabs/Structures/Military/Houses/GarageMilitary_E_01/GarageMilitary_E_01_base.et
+++ b/Prefabs/Structures/Military/Houses/GarageMilitary_E_01/GarageMilitary_E_01_base.et
@@ -20,29 +20,21 @@ SCR_DestructibleBuildingEntity : "{A43A100E3C377DB2}Prefabs/Structures/Core/Buil
     OVT_ParkingPointInfo "{5D969965DA26FED7}" {
      Offset 0 0.413 16.417
      Angles 0 90 0
-     m_vPosition 0 0.413 16.417
-     m_vAngles 0 90 0
      m_Type PARKING_CAR
     }
     OVT_ParkingPointInfo "{5D96996445057A60}" {
      Offset 9.266 0.413 16.417
      Angles 0 90 0
-     m_vPosition 9.266 0.413 16.417
-     m_vAngles 0 90 0
      m_Type PARKING_CAR
     }
     OVT_ParkingPointInfo "{5D9699645B598E58}" {
      Offset -9 0.413 16.417
      Angles 0 90 0
-     m_vPosition -9 0.413 16.417
-     m_vAngles 0 90 0
      m_Type PARKING_CAR
     }
     OVT_ParkingPointInfo "{5D9699642AF37788}" {
      Offset 21.218 0.413 16.417
      Angles 0 90 0
-     m_vPosition 21.218 0.413 16.417
-     m_vAngles 0 90 0
      m_Type PARKING_CAR
     }
    }
@@ -50,6 +42,9 @@ SCR_DestructibleBuildingEntity : "{A43A100E3C377DB2}Prefabs/Structures/Core/Buil
   OVT_ShopComponent "{5D94EEDC33C2E769}" {
    m_ShopType SHOP_VEHICLE
    m_bProcurement 1
+  }
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
   }
  }
 }

--- a/Scripts/Game/GameMode/Managers/OVT_TownManagerComponent.c
+++ b/Scripts/Game/GameMode/Managers/OVT_TownManagerComponent.c
@@ -26,7 +26,9 @@ class OVT_TownData : Managed
 	
 	int SupportPercentage()
 	{
-		return Math.Round((support / population) * 100);
+		if(population == 0) 
+			return 0;
+		return Math.Round((support / population ) * 100);
 	}
 	
 	OVT_Faction ControllingFaction()

--- a/Worlds/MP/OVT_Campaign_Test_Layers/default.layer
+++ b/Worlds/MP/OVT_Campaign_Test_Layers/default.layer
@@ -75,6 +75,11 @@ $grp GenericEntity {
  }
 }
 SCR_DestructibleBuildingEntity : "{00FD2B4A0BDEC271}Prefabs/Structures/Commercial/FuelStations/FuelStation_E_01_building.et" {
+ components {
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 0
+  }
+ }
  coords 240.87 0.001 76.83
  angleY -89.85
 }
@@ -149,6 +154,11 @@ Tree : "{9025E96A11516E7A}Prefabs/Vegetation/Bush/b_juniperus_communis_2w.et" {
  coords 182.721 0.001 126.162
 }
 SCR_DestructibleBuildingEntity : "{92E8F78BCF17D93D}Prefabs/Structures/Commercial/Shops/ShopHouse_E_2I01t_clothesstore.et" {
+ components {
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
+  }
+ }
  coords 191.848 0.001 87.529
 }
 GenericEntity : "{9BF7399A6F63D480}Prefabs/GameMode/OVT_Port.et" {
@@ -171,6 +181,11 @@ Tree : "{BA785041AC632123}Prefabs/Vegetation/Bush/b_salix_cinerea_1.et" {
  coords 179.952 0.001 121.315
 }
 SCR_DestructibleBuildingEntity : "{CFE8511B2B7E8AAA}Prefabs/Structures/Commercial/Shops/ShopModern_E_01.et" {
+ components {
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
+  }
+ }
  coords 210.935 0.001 93.913
 }
 Tree : "{D9DF1D13919F19A0}Prefabs/Vegetation/Bush/b_rosa_canina_0s.et" {
@@ -190,6 +205,11 @@ SCR_SiteSlotEntity : "{F4066B8425BEC47C}PrefabsEditable/Slots/Road/E_SlotRoadMed
  }
 }
 SCR_DestructibleBuildingEntity : "{F51B9B9BD15BBE64}Prefabs/Structures/Commercial/Shops/ShopHouse_E_2I01t_householdwares.et" {
+ components {
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
+  }
+ }
  coords 166.601 0.001 87.468
 }
 StaticModelEntity : "{F808145ADD4EF885}PrefabLibrary/Walls/Metal/MetalGate_01_Long.et" {
@@ -201,5 +221,10 @@ SCR_DestructibleBuildingEntity : "{FBCE1861B987EA68}Prefabs/Structures/Military/
  angleY -90.081
 }
 SCR_DestructibleBuildingEntity : "{FF48B5059EB0AC65}Prefabs/Structures/Commercial/Shops/ShopHouse_E_2I01t_drugstore.et" {
+ components {
+  RplComponent "{50A4E7C9B5728062}" {
+   Enabled 1
+  }
+ }
  coords 179.27 0.001 87.654
 }


### PR DESCRIPTION
This fixes shops not working and some other structures that should have their RPL Components enabled.

Some other prefabs that don't have an Overthrow prefab in their hierarchy still need to be fixed