### PR TITLE
Fix: EconomyInfo fixes & optimization

### DIFF
--- a/Scripts/Game/UI/HUD/OVT_EconomyInfo.c
+++ b/Scripts/Game/UI/HUD/OVT_EconomyInfo.c
@@ -50,8 +50,9 @@ class OVT_EconomyInfo : SCR_InfoDisplay {
 			HideQRF();
 		}
 		
-		if(m_fOverrideCounter >= 2)
+		if(m_fOverrideCounter >= 1)
 		{
+			m_fOverrideCounter = 0;
 			UpdateOverride();
 		}
 		

--- a/Scripts/Game/UI/HUD/OVT_EconomyInfo.c
+++ b/Scripts/Game/UI/HUD/OVT_EconomyInfo.c
@@ -95,30 +95,37 @@ class OVT_EconomyInfo : SCR_InfoDisplay {
 		}
 	}
 	
+	// FindOverride gets called a lot, so make it a tiny bit faster by having the pointer here
+	protected Managed m_foundComponent;
 	protected bool FindOverride(IEntity entity)
 	{
-		OVT_MainMenuContextOverrideComponent found = OVT_MainMenuContextOverrideComponent.Cast(entity.FindComponent(OVT_MainMenuContextOverrideComponent));
-		if(found) {
-			float dist = vector.Distance(entity.GetOrigin(),m_player.GetOrigin());
-			if(dist > found.m_fRange) return false;
-			if(m_fFoundRange == -1 || m_fFoundRange > dist)
+		m_foundComponent = entity.FindComponent(OVT_MainMenuContextOverrideComponent);
+		if(!m_foundComponent) return false;
+		
+		OVT_MainMenuContextOverrideComponent m_overrideComponent = OVT_MainMenuContextOverrideComponent.Cast(m_foundComponent);
+		if(!m_overrideComponent) return false;
+		
+		float dist = vector.Distance(entity.GetOrigin(),m_player.GetOrigin());
+		if(dist > m_overrideComponent.m_fRange) return false;
+		
+		if(m_fFoundRange == -1 || m_fFoundRange > dist)
+		{
+			bool got = true;
+			if(m_overrideComponent.m_bMustOwnBase)
 			{
-				bool got = true;
-				if(found.m_bMustOwnBase)
+				OVT_BaseData base = OVT_Global.GetOccupyingFaction().GetNearestBase(entity.GetOrigin());
+				if(!base || base.IsOccupyingFaction())
 				{
-					OVT_BaseData base = OVT_Global.GetOccupyingFaction().GetNearestBase(entity.GetOrigin());
-					if(!base || base.IsOccupyingFaction())
-					{
-						got = false;
-					}
+					got = false;
 				}
-				if(got)
-				{
-					m_FoundOverride = found;
-					m_fFoundRange = dist;
-				}
-			}			
+			}
+			if(got)
+			{
+				m_FoundOverride = m_overrideComponent;
+				m_fFoundRange = dist;
+			}
 		}
+		
 		return false;
 	}
 	


### PR DESCRIPTION
In ``OVT_EconomyInfo``, ``m_fOverrideCounter`` is never reset, and override is updated every frame(?). Now it is set to update every second with a working timer. This is pretty significant because finding the override means checking the components of every entity within 50 meters, which is a really slow operation.

Average timings from the script profiler:

[Before](https://cdn.discordapp.com/attachments/512317720168103955/1250412050144821329/image.png?ex=666ad878&is=666986f8&hm=7efdea1bee4be2780792931db0fc994f08109646bdd6550e6c5b3c0d4aabcbb7&):
``OVT_EconomyInfo::UpdateOverride`` - 386.10us
``OVT_EconomyInfo::FindOverride`` - 265.50us

[After](https://cdn.discordapp.com/attachments/512317720168103955/1250429940034179184/image.png?ex=666ae921&is=666997a1&hm=ee13d055f2bebf0e59b7923ba886aded0e78c142977d90330a524b4cae53d940&):
``OVT_EconomyInfo::UpdateOverride`` - 5.50us
``OVT_EconomyInfo::FindOverride`` - 3.70us

One potential side-effect of this PR is that finding buildings for the UI override *might* sometimes be noticeably delayed, but I believe that this slight annoyance is worth it, and reading the code I believe this is what was originally intended anyway.

Edit:
Further optimized FindOverride by casting only when necessary and managing a single pointer instead of always creating a new one