### PR TITLE
Fix: VM errors from CanBeShownScript

### DIFF
--- a/Scripts/Game/UserActions/OVT_ManageBaseAction.c
+++ b/Scripts/Game/UserActions/OVT_ManageBaseAction.c
@@ -22,7 +22,13 @@ class OVT_ManageBaseAction : ScriptedUserAction
 
 	override bool CanBeShownScript(IEntity user)
 	{
-		return !EPF_Component<OVT_BaseControllerComponent>.Find(GetOwner()).IsOccupyingFaction();
+		OVT_BaseControllerComponent baseController = EPF_Component<OVT_BaseControllerComponent>.Find(GetOwner());
+		if (!baseController)
+		{
+			Print("OVT_ManageBaseAction.CanBeShownScript: Null BaseControllerComponent! Exiting", LogLevel.WARNING);
+			return false;
+		}
+		return !baseController.IsOccupyingFaction();
 	}
 
 	override bool HasLocalEffectOnlyScript() { return true; };

--- a/Scripts/Game/UserActions/OVT_SetHomeAction.c
+++ b/Scripts/Game/UserActions/OVT_SetHomeAction.c
@@ -28,7 +28,13 @@ class OVT_SetHomeAction : ScriptedUserAction
 	
 	override bool CanBeShownScript(IEntity user)
 	{
-		return !EPF_Component<OVT_BaseControllerComponent>.Find(GetOwner()).IsOccupyingFaction();
+		OVT_BaseControllerComponent baseController = EPF_Component<OVT_BaseControllerComponent>.Find(GetOwner());
+		if (!baseController)
+		{
+			Print("OVT_SetHomeAction.CanBeShownScript: Null BaseControllerComponent! Exiting", LogLevel.WARNING);
+			return false;
+		}
+		return !baseController.IsOccupyingFaction();
 	}
 	
 	override bool HasLocalEffectOnlyScript() { return true; };


### PR DESCRIPTION
Component could be NULL here (though it never should), so handle it and prevent the VM errors (NULL pointer to instance).

I believe that a FOB placed using the #56 exploit is required to trigger these VM errors, but I believe the code should handle them even if these errors *should* be unreachable.

Edit: #56 is in fact not required, and regularly placed FOB's will also throw this error.

I'd like verification that the type for ``baseController`` is correct, I am still kinda new to this Enfusion thing.

![image](https://github.com/ArmaOverthrow/Overthrow.Arma4/assets/30532050/00e3adf9-56c5-4488-9abd-7ea5a79dda22)
