### PR TITLE
Chore: Remove obsolete methods

### DIFF
--- a/Scripts/Game/Components/OVT_MainMenuContextOverrideComponent.c
+++ b/Scripts/Game/Components/OVT_MainMenuContextOverrideComponent.c
@@ -63,7 +63,7 @@ class OVT_MainMenuContextOverrideComponent : OVT_Component
 		
 		SCR_CompartmentAccessComponent compartment = SCR_CompartmentAccessComponent.Cast(player.FindComponent(SCR_CompartmentAccessComponent));
 				
-		if(compartment && compartment.IsInCompartment() && compartment.GetCompartmentType(compartment.GetCompartment()) == ECompartmentType.Pilot){
+		if(compartment && compartment.IsInCompartment() && compartment.GetCompartment().GetType() == ECompartmentType.Pilot){
 			isDriver = true;
 		}
 		

--- a/Scripts/Game/GameMode/Managers/OVT_PersistenceManagerComponent.c
+++ b/Scripts/Game/GameMode/Managers/OVT_PersistenceManagerComponent.c
@@ -37,9 +37,9 @@ class OVT_PersistenceManagerComponent : EPF_PersistenceManagerComponent
 #ifdef PLATFORM_XBOX
 		return;
 #endif
-		System.FindFiles(DeleteFileCallback, DB_BASE_DIR, ".json");
-		System.FindFiles(DeleteFileCallback, DB_BASE_DIR, ".bin");
-		System.FindFiles(DeleteFileCallback, DB_BASE_DIR, string.Empty);
+		FileIO.FindFiles(DeleteFileCallback, DB_BASE_DIR, ".json");
+		FileIO.FindFiles(DeleteFileCallback, DB_BASE_DIR, ".bin");
+		FileIO.FindFiles(DeleteFileCallback, DB_BASE_DIR, string.Empty);
 		FileIO.DeleteFile(DB_BASE_DIR);
 	}
 	

--- a/Scripts/Game/UI/Context/OVT_MapContext.c
+++ b/Scripts/Game/UI/Context/OVT_MapContext.c
@@ -397,7 +397,7 @@ class OVT_MapContext : OVT_UIContext
 					if (compartmentAccess)
 					{
 						BaseCompartmentSlot slot = compartmentAccess.GetCompartment();
-						if(SCR_CompartmentAccessComponent.GetCompartmentType(slot) == ECompartmentType.Pilot)
+						if(slot.GetType() == ECompartmentType.Pilot)
 						{
 							if(cost > 0)
 								m_Economy.TakePlayerMoney(m_iPlayerID, cost);

--- a/Scripts/Game/UI/Context/OVT_VehicleMenuContext.c
+++ b/Scripts/Game/UI/Context/OVT_VehicleMenuContext.c
@@ -14,7 +14,7 @@ class OVT_VehicleMenuContext : OVT_UIContext
 		SCR_CompartmentAccessComponent compartment = SCR_CompartmentAccessComponent.Cast(m_Owner.FindComponent(SCR_CompartmentAccessComponent));
 		if(!compartment) return false;
 		
-		if(compartment.IsInCompartment() && compartment.GetCompartmentType(compartment.GetCompartment()) == ECompartmentType.Pilot){
+		if(compartment.IsInCompartment() && compartment.GetCompartment().GetType() == ECompartmentType.Pilot){
 			return true;
 		}
 		return false;


### PR DESCRIPTION
Fixes these warnings from log:

```
SCRIPT    (W): @"Scripts/Game/Components/OVT_MainMenuContextOverrideComponent.c,66": 'GetCompartmentType' is obsolete: Use GetType() on the compartment instance directly.
SCRIPT    (W): @"Scripts/Game/GameMode/Managers/OVT_PersistenceManagerComponent.c,40": 'FindFiles' is obsolete: Use FileIO.FindFiles instead
SCRIPT    (W): @"Scripts/Game/GameMode/Managers/OVT_PersistenceManagerComponent.c,41": 'FindFiles' is obsolete: Use FileIO.FindFiles instead
SCRIPT    (W): @"Scripts/Game/GameMode/Managers/OVT_PersistenceManagerComponent.c,42": 'FindFiles' is obsolete: Use FileIO.FindFiles instead
SCRIPT    (W): @"Scripts/Game/UI/Context/OVT_MapContext.c,400": 'GetCompartmentType' is obsolete: Use GetType() on the compartment instance directly.
SCRIPT    (W): @"Scripts/Game/UI/Context/OVT_VehicleMenuContext.c,17": 'GetCompartmentType' is obsolete: Use GetType() on the compartment instance directly.
```

