### PR TITLE
Fix: Division by zero in OVT_TownSupportModifierSystem

### DIFF
--- a/Scripts/Game/GameMode/Systems/Modifiers/OVT_TownSupportModifierSystem.c
+++ b/Scripts/Game/GameMode/Systems/Modifiers/OVT_TownSupportModifierSystem.c
@@ -28,6 +28,14 @@ class OVT_TownSupportModifierSystem : OVT_TownModifierSystem
 		if(supportmods > 100) supportmods = 100;
 		if(supportmods < -100) supportmods = -100;
 		
+		// Prevent division by zero and dump info
+		if(max == 0)
+		{
+			Print("OVT_TownSupportModifierSystem.Recalculate - passed zero as max value, exiting with baseValue", LogLevel.ERROR);
+			PrintFormat("modifiers: %1 - baseValue: %2 - min: %3 - max: %4", modifiers, baseValue, min, max);
+			return baseValue;
+		}
+		
 		int supportPerc = Math.Round((newsupport / max) * 100);
 		
 		if(supportmods > 75)


### PR DESCRIPTION
Make code safe from division error, even though this variable should never be zero. It's a practically zero-cost failsafe so why not. We'll be returning the baseValue if this triggers just to keep everything running smoothly (no change in support).

One problem with this however is that it does not fix the root cause (towns having 0 population). I've added some logging here to hopefully get clues on fixing that eventually.

The report by @CowboyPilotUSA (picture below) points to L25 and this fixes L31, but I believe the VM just pointed to a wrong line, I don't think L25 is capable of throwing a 'division by zero' error under any circumstance.

![image](https://github.com/ArmaOverthrow/Overthrow.Arma4/assets/30532050/9fb38c59-d95b-425b-82c5-789568080ef1)