### PR TITLE
Initial 1.2 Compatibility

### DIFF
--- a/Scripts/Game/Components/OVT_MainMenuContextOverrideComponent.c
+++ b/Scripts/Game/Components/OVT_MainMenuContextOverrideComponent.c
@@ -63,7 +63,7 @@ class OVT_MainMenuContextOverrideComponent : OVT_Component
 		
 		SCR_CompartmentAccessComponent compartment = SCR_CompartmentAccessComponent.Cast(player.FindComponent(SCR_CompartmentAccessComponent));
 				
-		if(compartment && compartment.IsInCompartment() && compartment.GetCompartmentType(compartment.GetCompartment()) == ECompartmentType.Pilot){
+		if(compartment && compartment.IsInCompartment() && compartment.GetCompartmentType(compartment.GetCompartment()) == ECompartmentType.PILOT){
 			isDriver = true;
 		}
 		

--- a/Scripts/Game/Controllers/OccupyingFaction/BaseUpgrades/OVT_BaseUpgradeComposition.c
+++ b/Scripts/Game/Controllers/OccupyingFaction/BaseUpgrades/OVT_BaseUpgradeComposition.c
@@ -87,7 +87,7 @@ class OVT_BaseUpgradeComposition : OVT_SlottedBaseUpgrade
 		SCR_BaseCompartmentManagerComponent compartment = EPF_Component<SCR_BaseCompartmentManagerComponent>.Find(entity);
 		if(!compartment) return true;		
 		
-		compartment.SpawnDefaultOccupants({ECompartmentType.Turret});
+		compartment.SpawnDefaultOccupants({ECompartmentType.TURRET});
 		
 		return true;
 	}

--- a/Scripts/Game/GameMode/Managers/Factions/OVT_ResistanceFactionManager.c
+++ b/Scripts/Game/GameMode/Managers/Factions/OVT_ResistanceFactionManager.c
@@ -401,7 +401,7 @@ class OVT_ResistanceFactionManager: OVT_Component
 		SCR_CompartmentAccessComponent access = SCR_CompartmentAccessComponent.Cast(ent.FindComponent(SCR_CompartmentAccessComponent));
 		if(!access) return;
 		
-		access.MoveInVehicle(m_TempVehicle, ECompartmentType.Turret);
+		access.MoveInVehicle(m_TempVehicle, ECompartmentType.TURRET);
 	}
 	
 	void SpawnGunner(RplId turret, int playerId = -1, bool takeSupporter = true)

--- a/Scripts/Game/UI/Context/OVT_MapContext.c
+++ b/Scripts/Game/UI/Context/OVT_MapContext.c
@@ -397,7 +397,7 @@ class OVT_MapContext : OVT_UIContext
 					if (compartmentAccess)
 					{
 						BaseCompartmentSlot slot = compartmentAccess.GetCompartment();
-						if(SCR_CompartmentAccessComponent.GetCompartmentType(slot) == ECompartmentType.Pilot)
+						if(SCR_CompartmentAccessComponent.GetCompartmentType(slot) == ECompartmentType.PILOT)
 						{
 							if(cost > 0)
 								m_Economy.TakePlayerMoney(m_iPlayerID, cost);

--- a/Scripts/Game/UI/Context/OVT_VehicleMenuContext.c
+++ b/Scripts/Game/UI/Context/OVT_VehicleMenuContext.c
@@ -14,7 +14,7 @@ class OVT_VehicleMenuContext : OVT_UIContext
 		SCR_CompartmentAccessComponent compartment = SCR_CompartmentAccessComponent.Cast(m_Owner.FindComponent(SCR_CompartmentAccessComponent));
 		if(!compartment) return false;
 		
-		if(compartment.IsInCompartment() && compartment.GetCompartmentType(compartment.GetCompartment()) == ECompartmentType.Pilot){
+		if(compartment.IsInCompartment() && compartment.GetCompartmentType(compartment.GetCompartment()) == ECompartmentType.PILOT){
 			return true;
 		}
 		return false;

--- a/Scripts/Game/UserActions/Modded/SCR_GetInUserAction.c
+++ b/Scripts/Game/UserActions/Modded/SCR_GetInUserAction.c
@@ -17,7 +17,7 @@ modded class SCR_GetInUserAction : SCR_CompartmentUserAction
 		if (!compartmentAccess)
 			return;
 		
-		if (!compartmentAccess.GetInVehicle(pOwnerEntity, targetCompartment, GetRelevantDoorIndex(pUserEntity)))
+		if (!compartmentAccess.GetInVehicle(pOwnerEntity, targetCompartment, false, GetRelevantDoorIndex(pUserEntity), ECloseDoorAfterActions.RETURN_TO_PREVIOUS_STATE, false))
 			return;
 		
 		OVT_OverthrowGameMode ot = OVT_OverthrowGameMode.Cast(GetGame().GetGameMode());
@@ -83,7 +83,7 @@ modded class SCR_GetInUserAction : SCR_CompartmentUserAction
 		}
 		
 		// Make sure vehicle can be enter via provided door, if not, set reason.
-		if (!compartmentAccess.CanGetInVehicleViaDoor(owner, compartment, GetRelevantDoorIndex(user)))
+		if (!compartmentAccess.CanGetInVehicleViaDoor(owner, m_CompartmentManager, GetRelevantDoorIndex(user)))
 		{
 			SetCannotPerformReason("#AR-UserAction_SeatObstructed");
 			return false;

--- a/Scripts/Game/UserActions/OVT_HireGunnerAction.c
+++ b/Scripts/Game/UserActions/OVT_HireGunnerAction.c
@@ -16,7 +16,7 @@ class OVT_HireGunnerAction : ScriptedUserAction
 		if(!comp) return;
 		
 		array<BaseCompartmentSlot> slots = {};		
-		comp.GetCompartmentsOfType(slots, ECompartmentType.Turret);
+		comp.GetCompartmentsOfType(slots, ECompartmentType.TURRET);
 		if(slots.Count() == 0) return;
 		
 		BaseCompartmentSlot slot = slots[0];

--- a/Scripts/Game/UserActions/OVT_LoadStorageAction.c
+++ b/Scripts/Game/UserActions/OVT_LoadStorageAction.c
@@ -33,7 +33,7 @@ class OVT_LoadStorageAction : SCR_InventoryAction
 		Vehicle veh = Vehicle.Cast(nearestVeh);
 		SCR_BaseCompartmentManagerComponent access = SCR_BaseCompartmentManagerComponent.Cast(veh.FindComponent(SCR_BaseCompartmentManagerComponent));
 		array<IEntity> pilots = {};
-		access.GetOccupantsOfType(pilots, ECompartmentType.Pilot);
+		access.GetOccupantsOfType(pilots, ECompartmentType.PILOT);
 		
 		if(pilots.Count() > 0)
 		{

--- a/Scripts/Game/UserActions/OVT_ManageVehicleAction.c
+++ b/Scripts/Game/UserActions/OVT_ManageVehicleAction.c
@@ -21,7 +21,7 @@ class OVT_ManageVehicleAction : ScriptedUserAction
 		Vehicle veh = Vehicle.Cast(m_Vehicles[0]);
 		SCR_BaseCompartmentManagerComponent access = SCR_BaseCompartmentManagerComponent.Cast(veh.FindComponent(SCR_BaseCompartmentManagerComponent));
 		array<IEntity> pilots = {};
-		access.GetOccupantsOfType(pilots, ECompartmentType.Pilot);
+		access.GetOccupantsOfType(pilots, ECompartmentType.PILOT);
 		
 		if(pilots.Count() > 0)
 		{

--- a/Scripts/Game/UserActions/OVT_UnloadStorageAction.c
+++ b/Scripts/Game/UserActions/OVT_UnloadStorageAction.c
@@ -33,7 +33,7 @@ class OVT_UnloadStorageAction : SCR_InventoryAction
 		Vehicle veh = Vehicle.Cast(nearestVeh);
 		SCR_BaseCompartmentManagerComponent access = SCR_BaseCompartmentManagerComponent.Cast(veh.FindComponent(SCR_BaseCompartmentManagerComponent));
 		array<IEntity> pilots = {};
-		access.GetOccupantsOfType(pilots, ECompartmentType.Pilot);
+		access.GetOccupantsOfType(pilots, ECompartmentType.PILOT);
 		
 		if(pilots.Count() > 0)
 		{


### PR DESCRIPTION
### List of changes:
- All lowercase enums are now in uppercase, Reforger no longer seems to support case-mismatched enum values
- Some methods in SCR_GetInUserAction were changed in 1.2, made them equivalent to vanilla

Edit: There are other issues as well, such as civs spawning without clothing (presumably due to the inventory changes), but Integrity Gaming is working on those and they'll be part of a separate pull request.

Verified on:
- [x] Workbench test (builds and runs)
- [ ] Local hosted server
- [ ] Dedicated server