### PR TITLE
TryInsertItem() -> TryReplaceItem()

### DIFF
--- a/Scripts/Game/Controllers/OVT_TownController.c
+++ b/Scripts/Game/Controllers/OVT_TownController.c
@@ -125,8 +125,22 @@ class OVT_TownControllerComponent: OVT_Component
 			IEntity slotEntity = OVT_Global.SpawnDefaultCharacterItem(storageManager, loadoutItem);
 			if (!slotEntity) continue;
 			
-			if (!storageManager.TryInsertItem(slotEntity, EStoragePurpose.PURPOSE_LOADOUT_PROXY))
+			array<BaseInventoryStorageComponent> storages = new array<BaseInventoryStorageComponent>;
+			storageManager.GetStorages(storages, EStoragePurpose.PURPOSE_LOADOUT_PROXY);
+			
+			BaseInventoryStorageComponent loadoutStorage;
+			int suitableSlotId = -1;
+			if (!storages.IsEmpty()) {
+				loadoutStorage = storages[0];
+				InventoryStorageSlot suitableSlot = loadoutStorage.FindSuitableSlotForItem(slotEntity);
+				if (suitableSlot) {
+					suitableSlotId = suitableSlot.GetID();
+				}
+			}
+            
+			if (!loadoutStorage || suitableSlotId == -1 || !storageManager.TryReplaceItem(slotEntity, loadoutStorage, suitableSlotId))
 			{
+				Print("Failed to insert item " + slotEntity + " " + loadoutStorage + " " + suitableSlotId, LogLevel.WARNING); 
 				SCR_EntityHelper.DeleteEntityAndChildren(slotEntity);
 			}
 		}

--- a/Scripts/Game/GameMode/Managers/OVT_RespawnSystemComponent.c
+++ b/Scripts/Game/GameMode/Managers/OVT_RespawnSystemComponent.c
@@ -122,8 +122,22 @@ class OVT_RespawnSystemComponent : EPF_BaseRespawnSystemComponent
 					}
 				}
 				
-				if (!storageManager.TryInsertItem(slotEntity, EStoragePurpose.PURPOSE_LOADOUT_PROXY))
+				array<BaseInventoryStorageComponent> storages = new array<BaseInventoryStorageComponent>;
+				storageManager.GetStorages(storages, EStoragePurpose.PURPOSE_LOADOUT_PROXY);
+				
+				BaseInventoryStorageComponent loadoutStorage;
+				int suitableSlotId = -1;
+				if (!storages.IsEmpty()) {
+					loadoutStorage = storages[0];
+					InventoryStorageSlot suitableSlot = loadoutStorage.FindSuitableSlotForItem(slotEntity);
+					if (suitableSlot) {
+						suitableSlotId = suitableSlot.GetID();
+					}
+				}
+	            
+				if (!loadoutStorage || suitableSlotId == -1 || !storageManager.TryReplaceItem(slotEntity, loadoutStorage, suitableSlotId))
 				{
+					Print("Failed to insert item " + slotEntity + " " + loadoutStorage + " " + suitableSlotId, LogLevel.WARNING); 
 					SCR_EntityHelper.DeleteEntityAndChildren(slotEntity);
 				}
 			}

--- a/Scripts/Game/Global/OVT_Global.c
+++ b/Scripts/Game/Global/OVT_Global.c
@@ -460,8 +460,22 @@ class OVT_Global : Managed
 				slotEntity = SpawnDefaultCharacterItem(storageManager, loadoutItem);
 				if (!slotEntity) continue;
 				
-				if (!storageManager.TryInsertItem(slotEntity, EStoragePurpose.PURPOSE_LOADOUT_PROXY))
+				array<BaseInventoryStorageComponent> storages = new array<BaseInventoryStorageComponent>;
+				storageManager.GetStorages(storages, EStoragePurpose.PURPOSE_LOADOUT_PROXY);
+				
+				BaseInventoryStorageComponent loadoutStorage;
+				int suitableSlotId = -1;
+				if (!storages.IsEmpty()) {
+					loadoutStorage = storages[0];
+					InventoryStorageSlot suitableSlot = loadoutStorage.FindSuitableSlotForItem(slotEntity);
+					if (suitableSlot) {
+						suitableSlotId = suitableSlot.GetID();
+					}
+				}
+	            
+				if (!loadoutStorage || suitableSlotId == -1 || !storageManager.TryReplaceItem(slotEntity, loadoutStorage, suitableSlotId))
 				{
+					Print("Failed to insert item " + slotEntity + " " + loadoutStorage + " " + suitableSlotId, LogLevel.WARNING); 
 					SCR_EntityHelper.DeleteEntityAndChildren(slotEntity);
 				}
 			}

--- a/Scripts/Game/Respawn/Logic/OVT_PersistentRespawnLogic.c
+++ b/Scripts/Game/Respawn/Logic/OVT_PersistentRespawnLogic.c
@@ -153,8 +153,22 @@ class OVT_PersistentRespawnLogic : SCR_SpawnLogic
 			IEntity slotEntity = SpawnDefaultCharacterItem(storageManager, loadoutItem);
 			if (!slotEntity) continue;
 			
-			if (!storageManager.TryInsertItem(slotEntity, EStoragePurpose.PURPOSE_LOADOUT_PROXY))
+			array<BaseInventoryStorageComponent> storages = new array<BaseInventoryStorageComponent>;
+			storageManager.GetStorages(storages, EStoragePurpose.PURPOSE_LOADOUT_PROXY);
+			
+			BaseInventoryStorageComponent loadoutStorage;
+			int suitableSlotId = -1;
+			if (!storages.IsEmpty()) {
+				loadoutStorage = storages[0];
+				InventoryStorageSlot suitableSlot = loadoutStorage.FindSuitableSlotForItem(slotEntity);
+				if (suitableSlot) {
+					suitableSlotId = suitableSlot.GetID();
+				}
+			}
+            
+			if (!loadoutStorage || suitableSlotId == -1 || !storageManager.TryReplaceItem(slotEntity, loadoutStorage, suitableSlotId))
 			{
+				Print("Failed to insert item " + slotEntity + " " + loadoutStorage + " " + suitableSlotId, LogLevel.WARNING); 
 				SCR_EntityHelper.DeleteEntityAndChildren(slotEntity);
 			}
 		}


### PR DESCRIPTION
From Bohemia's comments, it is left ambiguous whether or not ``TryInsertItem()`` is supposed to be able to replace items. I *think* the answer is no, due to the following comment for ``TryReplaceItem()``: "Same as insert, only should allow replacing item at storage slot".

This pull request switches all ``PURPOSE_LOADOUT_PROXY`` purposed inserts for replace. No functional difference is expected.

It is a bit more code to do it this way, but I believe that this is more future-proof. 