### PR TITLE
[WIP] Added setting for starting items behavior

### DIFF
--- a/Scripts/Game/Configuration/OVT_DifficultySettings.c
+++ b/Scripts/Game/Configuration/OVT_DifficultySettings.c
@@ -78,6 +78,9 @@ class OVT_DifficultySettings : ScriptAndConfig
 	[Attribute(defvalue: "1000", desc: "Max size of QRF in resources", category: "QRF")]
 	int maxQRF;
 	
-	[Attribute("", UIWidgets.ResourcePickerThumbnail, "Items given to player when first spawned in")]
+	[Attribute(defvalue: "1", desc: "Add the items below only on first spawn", category: "Loadout", params: "0 1 1")]
+	int startingItemsSingleShot;
+	
+	[Attribute("", UIWidgets.ResourcePickerThumbnail, "Items given to player when first spawned in", category: "Loadout")]
 	ref array<ResourceName> startingItems;
 }


### PR DESCRIPTION
### Rationale

I've seen this being asked for by others and I find this feature a must have myself. The original behavior is a design choice by the author, so this is introduced as an option for server admins.

### Changes

- added "startingItemsSingleShot" difficulty setting, which controls whether starting items for respawned player are added only once (current behavior), or on each respawn
- slightly improved code around

### Issues

If there is an existing save, the setting configured in scenario/prefab will never take effect, and instead 0 will be assumed as default value due to how EPF works, effectively changing behavior for existing sessions.

This can be resolved by:
- inverting the logic so that 0 value will mean "spawn single shot", but it's a workaround which doesn't solve the problem that the difficulty object is not future-proofed
- removing OVT_DifficultyLevel serialization (which I twink is best) 
- manually changing the save data (needs to be done by each admin server after upgrading, no one wants to do that)

Note this will conflict with #73, but conflict is straightforward to resolve.

### How to test

- Set property to 1, die, you shouldn't have starting items in your equipment.
- Set property to 0, die several times, you should always have starting items in your equipment.
- Join as another player (or wipe your save), you should have starting items in your equipment regardless of the property state.
