### PR TITLE
fix: flying town locations

### DIFF
--- a/Scripts/Game/GameMode/Managers/OVT_TownManagerComponent.c
+++ b/Scripts/Game/GameMode/Managers/OVT_TownManagerComponent.c
@@ -676,6 +676,7 @@ class OVT_TownManagerComponent: OVT_Component
 			
 		townID = m_iTownCount;
 		town.location = entity.GetOrigin();
+		town.location[1] = GetGame().GetWorld().GetSurfaceY(town.location[0], town.location[2]);
 		town.population = 0;
 		town.support = 0;
 		town.faction = GetGame().GetFactionManager().GetFactionIndex(faction);


### PR DESCRIPTION
Brings town locations to ground level. This fixes players spawning mid-air. Also makes distance checking towns a bit more accurate.

Hopefully fixes #48 

How to test:
1. Change the code so that the player doesn't get a house when starting
2. Start a fresh game of Overthrow Everon where you spawn in Chotain (in my testing this town is affected by the bug)
3. Check if you still fall to your doom with this PR