### PR TITLE
fix: Placement & Building exploits

### DIFF
--- a/Scripts/Game/UI/Context/OVT_MainMenuContext.c
+++ b/Scripts/Game/UI/Context/OVT_MainMenuContext.c
@@ -223,6 +223,10 @@ class OVT_MainMenuContext : OVT_UIContext
 	private void Build()
 	{
 		CloseLayout();
+		if (m_UIManager.GetContext(OVT_PlaceContext))
+		{	// A hack, we need to close PlaceContext to avoid both of them being open at the same time
+			OVT_PlaceContext.Cast(m_UIManager.GetContext(OVT_PlaceContext)).Cancel();
+		}
 		m_UIManager.ShowContext(OVT_BuildContext);		
 	}
 	

--- a/Scripts/Game/UI/Context/OVT_PlaceContext.c
+++ b/Scripts/Game/UI/Context/OVT_PlaceContext.c
@@ -229,6 +229,13 @@ class OVT_PlaceContext : OVT_UIContext
 	void StartPlace(OVT_Placeable placeable)
 	{
 		if(m_bIsActive) CloseLayout();
+		
+		// Already placing something, remove the old one
+		if (m_bPlacing)
+		{
+			RemoveGhost();
+			m_bPlacing = false;
+		}
 
 		IEntity player = SCR_PlayerController.GetLocalControlledEntity();
 
@@ -249,8 +256,11 @@ class OVT_PlaceContext : OVT_UIContext
 			return;
 		}
 
-		WorkspaceWidget workspace = GetGame().GetWorkspace();
-		m_PlaceWidget = workspace.CreateWidgets(m_PlaceLayout);
+		if (!m_PlaceWidget)
+		{
+			WorkspaceWidget workspace = GetGame().GetWorkspace();
+			m_PlaceWidget = workspace.CreateWidgets(m_PlaceLayout);
+		}
 
 		m_bPlacing = true;
 		m_iPrefabIndex = 0;


### PR DESCRIPTION
## Fixed exploits:

### Free placement exploit
If you start placing something, open the U menu and start placing again, the previous "ghost" object is not deleted

### Widget "leak"
If you place something down, you will automatically start a new placement, but this will also "leak" the widget in the bottom right corner, because it will create a new widget every time and leave the old widget "dangling" without a variable.

### Overlapping placing and building
If you start placing something, open the U menu and start **building**, the placement system is still running and you will place down an object on top of the one you build

Closes #56 