### PR TITLE
Update OVT_OverthrowConfigComponent.c

### DIFF
--- a/Scripts/Game/GameMode/Managers/OVT_OverthrowConfigComponent.c
+++ b/Scripts/Game/GameMode/Managers/OVT_OverthrowConfigComponent.c
@@ -505,7 +505,8 @@ class OVT_OverthrowConfigComponent: OVT_Component
 		writer.WriteFloat(m_Difficulty.realEstateCostMultiplier);
 		writer.WriteInt(m_Difficulty.busTicketPrice);
 		writer.WriteInt(m_Difficulty.baseRecruitCost);
-		writer.WriteInt(m_Difficulty.gunDealerSellPriceMultiplier);
+		//SPARKNUTZ changing WriteInt to WriteFloat because gun DealerSellPriceMultiplier is a Float
+		writer.WriteFloat(m_Difficulty.gunDealerSellPriceMultiplier);
 		writer.WriteInt(m_Difficulty.procurementMultiplier);		
 		
 		return true;
@@ -543,8 +544,10 @@ class OVT_OverthrowConfigComponent: OVT_Component
 		if (!reader.ReadInt(i)) return false;
 		m_Difficulty.baseRecruitCost = i;
 		
-		if (!reader.ReadInt(i)) return false;
-		m_Difficulty.gunDealerSellPriceMultiplier = i;
+		//SPARKNUTZ changed Int to Float since the variable called is a float
+		
+		if (!reader.ReadFloat(f)) return false;
+		m_Difficulty.gunDealerSellPriceMultiplier = f;
 		
 		if (!reader.ReadInt(i)) return false;
 		m_Difficulty.procurementMultiplier = i;


### PR DESCRIPTION
Fixed Gun Dealers not selling on dedicated servers. I assume the read and write stream was setting the gundealersellmultiplier to 0 since there was a conflict in some thing calling it an int while the variable was a float. It may have rounded it to 0 since the default number is 0.5.