### PR TITLE
Remove duplicate TimeAndWeatherHandlerComponent

### DIFF
--- a/Assets/Items/Misc/Weed_01/Data/Material_u1_v1.emat.meta
+++ b/Assets/Items/Misc/Weed_01/Data/Material_u1_v1.emat.meta
@@ -11,5 +11,7 @@ MetaFileClass {
   }
   EMATResourceClass HEADLESS : PC {
   }
+  EMATResourceClass PS5 : PC {
+  }
  }
 }

--- a/Prefabs/GameMode/OVT_OverthrowGameMode.et
+++ b/Prefabs/GameMode/OVT_OverthrowGameMode.et
@@ -362,9 +362,6 @@ OVT_OverthrowGameMode {
   }
   SCR_SupportStationManagerComponent "{5EE26402C9203074}" {
   }
-  SCR_TimeAndWeatherHandlerComponent "{5EE26402AC31F891}" {
-   m_bRandomWeatherChanges 1
-  }
   SCR_VotingManagerComponent "{5EE26402B4C7BB47}" {
   }
   SerializerInventoryStorageManagerComponent "{5EE26402B9CEA8E5}" {
@@ -373,8 +370,8 @@ OVT_OverthrowGameMode {
    Streamable Disabled
   }
  }
- coords 208.286 1.001 116.919
  Flags 0
+ coords 208.286 1.001 116.919
  m_bAutoPlayerRespawn 0
  m_StartGameUIContext OVT_StartGameContext "{599D315949D3D5D0}" {
   m_Layout "{4A7A8EED9F6F2A92}UI/Layouts/Menu/StartGameMenu.layout"

--- a/Worlds/MP/OVT_Campaign_Eden_Layers/managers.layer
+++ b/Worlds/MP/OVT_Campaign_Eden_Layers/managers.layer
@@ -281,9 +281,6 @@ OVT_OverthrowGameMode OVT_OverthrowGameMode1 : "{4DC10DCB8BE06D32}Prefabs/GameMo
   SCR_RespawnTimerComponent "{59C30B0685EFBB8C}" {
    m_fRespawnTime 2
   }
-  SCR_TimeAndWeatherHandlerComponent "{5EE26402AC31F891}" {
-   m_bRandomWeatherChanges 1
-  }
   RplComponent "{59724C8C935D8E18}" {
    Streamable Disabled
   }

--- a/Worlds/MP/OVT_Campaign_Test_Layers/default.layer
+++ b/Worlds/MP/OVT_Campaign_Test_Layers/default.layer
@@ -290,9 +290,6 @@ OVT_OverthrowGameMode OVT_OverthrowGameMode : "{4DC10DCB8BE06D32}Prefabs/GameMod
   SCR_RespawnTimerComponent "{59C30B0685EFBB8C}" {
    m_fRespawnTime 2
   }
-  SCR_TimeAndWeatherHandlerComponent "{5EE26402AC31F891}" {
-   m_bRandomWeatherChanges 1
-  }
   RplComponent "{59724C8C935D8E18}" {
    Streamable Disabled
   }
@@ -336,8 +333,8 @@ $grp GenericEntity {
     MainType "Name Town"
    }
   }
-  coords 221.182 1.001 107.325
   Flags 1027
+  coords 221.182 1.001 107.325
  }
  RadioTower {
   components {
@@ -345,8 +342,8 @@ $grp GenericEntity {
     MainType Transmitter
    }
   }
-  coords 29.444 1.001 116.796
   Flags 1027
+  coords 29.444 1.001 116.796
  }
 }
 SCR_DestructibleBuildingEntity : "{00FD2B4A0BDEC271}Prefabs/Structures/Commercial/FuelStations/FuelStation_E_01_building.et" {
@@ -470,9 +467,6 @@ SCR_SiteSlotEntity : "{881CE7B0098504C2}PrefabsEditable/Slots/Road/E_SlotRoadLar
 SCR_DestructibleBuildingEntity : "{8ACC8A8EB87A28FF}Prefabs/Structures/Houses/Village/House_Village_E_1I03/House_Village_E_1I03.et" {
  coords 207.502 0 182.332
 }
-Tree : "{9025E96A11516E7A}Prefabs/Vegetation/Bush/b_juniperus_communis_2w.et" {
- coords 182.721 0.001 126.162
-}
 SCR_DestructibleBuildingEntity : "{92E8F78BCF17D93D}Prefabs/Structures/Commercial/Shops/ShopHouse_E_2I01t_clothesstore.et" {
  components {
   RplComponent "{50A4E7C9B5728062}" {
@@ -486,6 +480,9 @@ SCR_MPDestructionManager : "{9BB369F2803C6F71}Prefabs/MP/MPDestructionManager.et
 }
 GenericEntity : "{9BF7399A6F63D480}Prefabs/GameMode/OVT_Port.et" {
  coords 143.682 1.001 246.857
+}
+Tree : "{A43BE7E364B5CD67}Prefabs/Vegetation/Bush/b_juniperus_communis_2w.et" {
+ coords 182.721 0.001 126.162
 }
 Tree : "{A5DE58FC9FB6BA60}Prefabs/Vegetation/Bush/b_corylus_avellana_2.et" {
  coords 183.058 0.001 122.114


### PR DESCRIPTION
Removes SCR_TimeAndWeatherHandlerComponent, as the gamemode already has OVT_TimeAndWeatherHandlerComponent, which inherits all functionality.

Backwards compatible with all maps. 3rd party map ports of Overthrow can but don't need to do this as well.

Also contains some weird changes to unrelated materials and variables that workbench insisted on making.