### PR TITLE
rework undercover system

### DIFF
--- a/Scripts/Game/Configuration/OVT_DifficultySettings.c
+++ b/Scripts/Game/Configuration/OVT_DifficultySettings.c
@@ -103,6 +103,16 @@ class OVT_DifficultySettings : ScriptAndConfig
 	float wantedReductionMultiplier;
 	[Attribute(defvalue: "0.6", desc: "Detection range multiplier when disguised", category: "Undercover System")]
 	float detectionRangeMultiplier;
+	[Attribute(defvalue: "90", desc: "Minimum faction points required for successful disguise", category: "Undercover System")]
+	int minimumDisguisePoints;
+	[Attribute(defvalue: "true", desc: "Require matching helmet for disguise", category: "Undercover System")]
+	bool requireUniformHelmet;
+	[Attribute(defvalue: "true", desc: "Require matching uniform top for disguise", category: "Undercover System")]
+	bool requireUniformTop;
+	[Attribute(defvalue: "true", desc: "Require matching pants for disguise", category: "Undercover System")]
+	bool requireUniformPants;
+	[Attribute(defvalue: "true", desc: "Require matching boots for disguise", category: "Undercover System")]
+	bool requireUniformBoots;
 	
 	[Attribute("", UIWidgets.ResourcePickerThumbnail, "Items given to player when first spawned in")]
 	ref array<ResourceName> startingItems;

--- a/Scripts/Game/UI/HUD/OVT_WantedInfo.c
+++ b/Scripts/Game/UI/HUD/OVT_WantedInfo.c
@@ -131,6 +131,7 @@ class OVT_WantedInfo : SCR_InfoDisplay {
 			bool isDisguised = m_Wanted.IsDisguisedAsOccupying();
 			int wantedLevel = m_Wanted.GetWantedLevel();
 			
+			
 			if (isDisguised)
 			{
 				// Red icon if wanted while disguised, blue if not wanted
@@ -144,10 +145,12 @@ class OVT_WantedInfo : SCR_InfoDisplay {
 				}
 				showIcon = true;
 			}
+			else
+			{
+			}
 		}
 		else
 		{
-			Print("[Overthrow] WARNING: m_Wanted is null!");
 		}
 		
 		// If not disguised, check perceived faction
@@ -164,6 +167,12 @@ class OVT_WantedInfo : SCR_InfoDisplay {
 			else
 			{
 				// No perceived faction means we appear as civilian
+				factionKey = "CIV";
+			}
+			
+			// WORKAROUND: If disguise was blocked due to incomplete uniform AND we're perceived as occupying faction, force civilian status
+			if (m_Wanted && m_Wanted.IsDisguiseBlockedByIncompleteUniform() && factionKey == occupyingFactionKey)
+			{
 				factionKey = "CIV";
 			}
 			


### PR DESCRIPTION
Remodified the detection system. Four main items of clothing: Headwear, Top, Bottom, and Footwear of the occupying faction are required to be disguised. Also if wearing a suit, it will account for that blocked slot. Before it was based only off meeting a threshold of points. So you could before wear civ pants with USSR outfit and be considered undercover.