### PR TITLE
Fix NULL pointer crash in HighlightAvailableStorages

### DIFF
--- a/Scripts/Game/UI/Inventory/Modded/SCR_InventoryMenuUI.c
+++ b/Scripts/Game/UI/Inventory/Modded/SCR_InventoryMenuUI.c
@@ -1,0 +1,31 @@
+//------------------------------------------------------------------------------------------------
+modded class SCR_InventoryMenuUI
+{
+	//------------------------------------------------------------------------------------------------
+	// Override to fix NULL pointer crash in vanilla implementation
+	override void HighlightAvailableStorages(SCR_InventorySlotUI itemSlot)
+	{
+		if (!itemSlot || !m_pActiveHoveredStorageUI || !m_aStorages)
+			return;
+
+		InventoryItemComponent itemComp = itemSlot.GetInventoryItemComponent();
+		if (!itemComp)
+			return;
+
+		foreach (SCR_InventoryStorageBaseUI storageBaseUI : m_aStorages)
+		{
+			if (!storageBaseUI)
+				continue;
+			if (storageBaseUI.Type() == SCR_InventoryStorageLootUI)
+				continue;
+			if (storageBaseUI == m_pActiveHoveredStorageUI)
+				continue;
+
+			BaseInventoryStorageComponent contStorage = storageBaseUI.GetStorage();
+			if (!contStorage)
+				continue;
+
+			storageBaseUI.SetStorageAsHighlighted(true);
+		}
+	}
+}


### PR DESCRIPTION
Overrides HighlightAvailableStorages in SCR_InventoryMenuUI to add null checks and prevent crashes in the vanilla implementation when certain UI or storage components are missing.

Original error, when you try to move items in your inventory during testing worlds these errors would pop up 

Virtual Machine Exception

Reason: NULL pointer to instance

Class:      'SCR_InventoryMenuUI'
Function: 'HighlightAvailableStorages'
Stack trace:
Scripts/Game/UI/Inventory/SCR_InventoryMenuUI.c:5122 Function HighlightAvailableStorages
Scripts/Game/UI/Inventory/SCR_InventoryMenuUI.c:4857 Function Action_OnDrag