### PR TITLE
fix: VME from SCR_InventoryMenuUI

### DIFF
--- a/Prefabs/GameMode/OVT_OverthrowGameMode.et
+++ b/Prefabs/GameMode/OVT_OverthrowGameMode.et
@@ -258,6 +258,11 @@ OVT_OverthrowGameMode {
   SCR_DestructionManagerComponent "{5DFEE7C5F4445327}" {
   }
   SCR_EntityCatalogManagerComponent "{5EE2640207CD57B9}" {
+   m_aEntityCatalogs {
+    SCR_EntityCatalog "{670303AAD2A95E6B}" {
+     m_eEntityCatalogType SUPPLY_CONTAINER_ITEM
+    }
+   }
   }
   SCR_GameModeHealthSettings "{5D7A443950718AF0}" {
   }


### PR DESCRIPTION
SCR_InventoryMenuUI causes a VME if this catalog is missing. I presume this catalog is for the Conflict gamemode, so we don't **actually** need to have it, it just needs to exist to get rid of this VME.

This has been reported to Bohemia twice now, and I will be adding details of this catalogue to the reports, as they weren't previously reported.

This fixes the same issue as #140 - but this way we don't need to override any UI methods.