### PR TITLE
(fix) Spawn placement: validate authored points, resolve real ground, keep gun dealers out of houses

### DIFF
--- a/Scripts/Game/Components/OVT_SpawnPointComponent.c
+++ b/Scripts/Game/Components/OVT_SpawnPointComponent.c
@@ -14,87 +14,159 @@ class OVT_SpawnPointComponent : ScriptComponent
 	[Attribute()]
 	ref array<ref PointInfo> m_aVehiclePoints;
 
+	//! Clearance boxes an authored point is tested against before it is handed out. Same dimensions the
+	//! WORKBENCH preview draws, so what the author sees is what gets validated.
+	static const vector PERSON_MINS = "-0.5 0 -0.5";
+	static const vector PERSON_MAXS = "0.5 2 0.5";
+	static const vector VEHICLE_MINS = "-1.5 0 -3";
+	static const vector VEHICLE_MAXS = "1.5 2.5 3";
+
 #ifdef WORKBENCH
 	protected ref array<ref Shape> m_aSpawnBoxes = {};
 #endif
 		
+	//! A world position at one of the authored pedestrian points, VALIDATED.
+	//!
+	//! The points are tried in a RANDOM ORDER and the first one clear of geometry wins, which is why
+	//! this can no longer just pick a random element: a base controller, a deployed FOB and a bus stop
+	//! each author fixed offsets on all four sides, and which of them is inside a wall depends entirely
+	//! on where the owner happens to have been placed. Picking blind put players in that wall. Only
+	//! when every point is blocked does the first one TRIED come back anyway - a blocked spawn still
+	//! beats no answer, and one picked at random is exactly what this method always used to return.
+	//!
+	//! Height comes from OVT_WorldUtils.ResolveGroundY, not GetSurfaceY: the terrain height ignores
+	//! the raised floor, foundation or pad the point was authored on and buries the spawn in it.
+	//! \return A world position, or the owner's origin when nothing is authored (see HasSpawnPoints).
 	vector GetSpawnPoint()
-	{		
-		vector outMat[4];
-		vector offsetMat[4];
-					
-		//Get building transform
-		GetOwner().GetTransform(outMat);
-		
-		// Use random point from array if available
-		if (m_aPoints && m_aPoints.Count() > 0)
+	{
+		vector ownerMat[4];
+		GetOwner().GetTransform(ownerMat);
+
+		array<PointInfo> candidates();
+		CollectPoints(m_aPoints, m_vPoint, candidates);
+
+		if (candidates.IsEmpty())
+			return ownerMat[3];
+
+		vector fallback = vector.Zero;
+		int count = candidates.Count();
+		int start = s_AIRandomGenerator.RandInt(0, count);
+
+		for (int i = 0; i < count; i++)
 		{
-			PointInfo selectedPoint = m_aPoints.GetRandomElement();
-			if (selectedPoint)
+			vector candidate = ResolvePointPosition(candidates[(start + i) % count], ownerMat);
+
+			if (i == 0)
+				fallback = candidate;
+
+			// The owner is excluded on purpose: an authored point sits ON or ALONGSIDE the thing that
+			// authored it (a truck's flank, a tent's doorway), so counting the owner would reject every
+			// point on a large prefab and fall through to the blocked-anyway fallback.
+			if (OVT_WorldUtils.IsPositionClear(candidate, PERSON_MINS, PERSON_MAXS, GetOwner()))
+				return candidate;
+		}
+
+		return fallback;
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! One authored point in world space, standing on the surface under it.
+	protected vector ResolvePointPosition(notnull PointInfo point, vector ownerMat[4])
+	{
+		vector offsetMat[4];
+		point.GetTransform(offsetMat);
+
+		// offset the item locally with building rotation
+		vector worldPos = offsetMat[3].Multiply4(ownerMat);
+		worldPos[1] = OVT_WorldUtils.ResolveGroundY(worldPos) + OVT_WorldUtils.SPAWN_GROUND_CLEARANCE;
+
+		return worldPos;
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! The authored points as one list: the array when it holds anything, else the single point.
+	protected void CollectPoints(array<ref PointInfo> points, PointInfo single, notnull array<PointInfo> outPoints)
+	{
+		outPoints.Clear();
+
+		if (points)
+		{
+			foreach (PointInfo point : points)
 			{
-				selectedPoint.GetTransform(offsetMat);
-				
-				// offset the item locally with building rotation
-				outMat[3] = offsetMat[3].Multiply4(outMat);
-				
-				//Set ground height to Y + 0.5m
-				outMat[3][1] = GetGame().GetWorld().GetSurfaceY(outMat[3][0],outMat[3][2]) + 0.5;	
-				
-				return outMat[3];
+				if (point)
+					outPoints.Insert(point);
 			}
 		}
-		
-		// Fallback to single point if array is empty or not set
-		if(!m_vPoint) return outMat[3];
-		
-		m_vPoint.GetTransform(offsetMat);
-		
-		// offset the item locally with building rotation
-		outMat[3] = offsetMat[3].Multiply4(outMat);
-		
-		//Set ground height to Y + 0.5m
-		outMat[3][1] = GetGame().GetWorld().GetSurfaceY(outMat[3][0],outMat[3][2]) + 0.5;	
-		
-		return outMat[3];
+
+		if (outPoints.IsEmpty() && single)
+			outPoints.Insert(single);
 	}
 	
+	//! A world transform at one of the authored vehicle points, VALIDATED the same way GetSpawnPoint is.
+	//!
+	//! An occupied arrival spot is worse for a vehicle than for a person - the car lands on top of
+	//! whatever is parked there - so a blocked point is skipped rather than used, and the first point
+	//! tried is only handed back when every one of them is blocked.
 	bool GetVehicleSpawnPoint(out vector position, out vector angles)
 	{
-		vector outMat[4];
-		vector offsetMat[4];
-					
-		//Get building transform
-		GetOwner().GetTransform(outMat);
-		
-		// Use random point from vehicle array if available
-		if (m_aVehiclePoints && m_aVehiclePoints.Count() > 0)
+		vector ownerMat[4];
+		GetOwner().GetTransform(ownerMat);
+
+		array<PointInfo> candidates();
+		CollectPoints(m_aVehiclePoints, null, candidates);
+
+		if (candidates.IsEmpty())
+			return false;
+
+		vector fallbackPos = vector.Zero;
+		vector fallbackAngles = vector.Zero;
+		int count = candidates.Count();
+		int start = s_AIRandomGenerator.RandInt(0, count);
+
+		for (int i = 0; i < count; i++)
 		{
-			PointInfo selectedPoint = m_aVehiclePoints.GetRandomElement();
-			if (selectedPoint)
+			PointInfo point = candidates[(start + i) % count];
+
+			vector offsetMat[4];
+			point.GetTransform(offsetMat);
+
+			vector outMat[4];
+			GetOwner().GetTransform(outMat);
+
+			// offset the item locally with building rotation
+			outMat[3] = offsetMat[3].Multiply4(ownerMat);
+
+			// Apply rotation (QuatToMatrix writes the 3x3 only, so the position above survives)
+			float qt[4];
+			float q[4];
+			Math3D.MatrixToQuat(ownerMat, qt);
+			Math3D.MatrixToQuat(offsetMat, q);
+			Math3D.QuatMultiply(qt, q, qt);
+			Math3D.QuatToMatrix(qt, outMat);
+
+			vector spot = outMat[3];
+			spot[1] = OVT_WorldUtils.ResolveGroundY(spot) + OVT_WorldUtils.SPAWN_GROUND_CLEARANCE;
+			outMat[3] = spot;
+
+			vector spotAngles = Math3D.MatrixToAngles(outMat);
+
+			if (i == 0)
 			{
-				selectedPoint.GetTransform(offsetMat);
-				
-				// offset the item locally with building rotation
-				outMat[3] = offsetMat[3].Multiply4(outMat);
-				
-				// Apply rotation
-				float qt[4];
-				float q[4];
-				Math3D.MatrixToQuat(outMat, qt);
-				Math3D.MatrixToQuat(offsetMat, q);
-				Math3D.QuatMultiply(qt, q, qt);
-				Math3D.QuatToMatrix(qt, outMat);
-				
-				//Set ground height to Y + 0.5m
-				outMat[3][1] = GetGame().GetWorld().GetSurfaceY(outMat[3][0],outMat[3][2]) + 0.5;	
-				
-				position = outMat[3];
-				angles = Math3D.MatrixToAngles(outMat);
+				fallbackPos = spot;
+				fallbackAngles = spotAngles;
+			}
+
+			if (OVT_WorldUtils.IsPositionClear(spot, VEHICLE_MINS, VEHICLE_MAXS, GetOwner()))
+			{
+				position = spot;
+				angles = spotAngles;
 				return true;
 			}
 		}
-		
-		return false;
+
+		position = fallbackPos;
+		angles = fallbackAngles;
+		return true;
 	}
 	
 	bool HasVehicleSpawnPoints()
@@ -191,17 +263,17 @@ class OVT_SpawnPointComponent : ScriptComponent
 		
 		if (isVehiclePoint)
 		{
-			// Vehicle spawn point dimensions (larger)
-			mins = "-1.5 0 -3";
-			maxs = "1.5 2.5 3";
+			// Vehicle spawn point dimensions (larger) - the box the runtime clearance test uses
+			mins = VEHICLE_MINS;
+			maxs = VEHICLE_MAXS;
 			// Orange color for vehicle spawn points
 			color = Color.FromRGBA(255, 165, 0, 128).PackToInt();
 		}
 		else
 		{
-			// Player spawn point dimensions
-			mins = "-0.5 0 -0.5";
-			maxs = "0.5 2 0.5";
+			// Player spawn point dimensions - the box the runtime clearance test uses
+			mins = PERSON_MINS;
+			maxs = PERSON_MAXS;
 			// Cyan color for player spawn points
 			color = Color.FromRGBA(0, 200, 255, 128).PackToInt();
 		}

--- a/Scripts/Game/Controllers/OVT_TownController.c
+++ b/Scripts/Game/Controllers/OVT_TownController.c
@@ -215,40 +215,53 @@ class OVT_TownControllerComponent: OVT_Component
 		return false;
 	}
 
+	//! A standing position for this town's gun dealer, OUTSIDE the house he belongs to.
+	//!
+	//! Anchoring on the building origin and asking FindSafeSpawnPosition was what stood dealers in
+	//! living rooms: the origin is a point inside the shell, the 2 m probe around it stays inside the
+	//! shell, and an empty room passes the clearance test. \see OVT_WorldUtils.FindSpawnPositionOutside
+	//! \param[in] house The building the dealer trades from.
+	//! \return A position beside the house, or its authored spawn point when it has one.
+	protected vector ResolveGunDealerPosition(notnull IEntity house)
+	{
+		OVT_SpawnPointComponent spawnPoint = OVT_SpawnPointComponent.Cast(house.FindComponent(OVT_SpawnPointComponent));
+		if(spawnPoint && spawnPoint.HasSpawnPoints())
+			return spawnPoint.GetSpawnPoint();
+
+		vector outside;
+		if(OVT_WorldUtils.FindSpawnPositionOutside(house, outside))
+			return outside;
+
+		return OVT_WorldUtils.FindSafeSpawnPosition(house.GetOrigin());
+	}
+
 	protected void SpawnGunDealer()
 	{
 		vector spawnPosition;
 
-		if(m_Town.gunDealerPosition && m_Town.gunDealerPosition[0] != 0)
+		// A RECORDED POSITION IS RE-TESTED, NOT TRUSTED. It is written to the save and re-used verbatim
+		// every session, so a dealer who once landed inside a house stayed there for the life of the
+		// campaign - re-judging it here is what heals an existing save on its next load. Both tests are
+		// needed: a dealer standing in an empty living room passes the clearance box exactly as one in
+		// the street does, and only the overhead trace can tell them apart. Compared against the zero
+		// vector rather than X != 0: a legitimate position can have X exactly 0 (BUG-005's shape).
+		if(m_Town.gunDealerPosition != vector.Zero
+			&& OVT_WorldUtils.IsPositionClear(m_Town.gunDealerPosition)
+			&& !OVT_WorldUtils.HasGeometryOverhead(m_Town.gunDealerPosition))
 		{
 			spawnPosition = m_Town.gunDealerPosition;
 		}else{
 			IEntity entity = GetRandomGunDealerHouse();
-			if(entity)
+			if(!entity)
+				entity = m_TownManager.GetRandomUnownedHouseInTown(m_Town);
+
+			if(!entity)
 			{
-				OVT_SpawnPointComponent spawnPoint = OVT_SpawnPointComponent.Cast(entity.FindComponent(OVT_SpawnPointComponent));
-				if(spawnPoint)
-				{
-					spawnPosition = spawnPoint.GetSpawnPoint();
-				}else{
-					spawnPosition = OVT_WorldUtils.FindSafeSpawnPosition(entity.GetOrigin());
-				}
-			}else{
-				IEntity house = m_TownManager.GetRandomUnownedHouseInTown(m_Town);
-				if(house)
-				{
-					OVT_SpawnPointComponent spawnPoint = OVT_SpawnPointComponent.Cast(house.FindComponent(OVT_SpawnPointComponent));
-					if(spawnPoint)
-					{
-						spawnPosition = spawnPoint.GetSpawnPoint();
-					}else{
-						spawnPosition = OVT_WorldUtils.FindSafeSpawnPosition(house.GetOrigin());
-					}
-				}else{
-					Print("[Overthrow] No gun dealer locations found in town: " + m_sName);
-					return;
-				}
-			}			
+				Print("[Overthrow] No gun dealer locations found in town: " + m_sName);
+				return;
+			}
+
+			spawnPosition = ResolveGunDealerPosition(entity);
 		}
 
 		BaseWorld world = GetGame().GetWorld();

--- a/Scripts/Game/GameMode/Civilians/OVT_TownCivilianSourceConfig.c
+++ b/Scripts/Game/GameMode/Civilians/OVT_TownCivilianSourceConfig.c
@@ -847,8 +847,10 @@ class OVT_TownCivilianSourceConfig : OVT_AmbientSpawnSourceConfig
 		if (m_aPlacementCache.Count() >= MAX_PLACEMENT_CANDIDATES)
 			return false;
 
+		// HasSpawnPoints() gates this: GetSpawnPoint() answers with the building's own origin when the
+		// component authors nothing, and caching that would place civilians inside the shell.
 		OVT_SpawnPointComponent spawnPoint = OVT_SpawnPointComponent.Cast(entity.FindComponent(OVT_SpawnPointComponent));
-		if (spawnPoint)
+		if (spawnPoint && spawnPoint.HasSpawnPoints())
 		{
 			vector authored = spawnPoint.GetSpawnPoint();
 			if (authored != vector.Zero && !OVT_WorldUtils.IsOceanAtPosition(authored))

--- a/Scripts/Game/GameMode/Managers/OVT_RealEstateManagerComponent.c
+++ b/Scripts/Game/GameMode/Managers/OVT_RealEstateManagerComponent.c
@@ -796,15 +796,24 @@ class OVT_RealEstateManagerComponent: OVT_OwnerManagerComponent
 	//! \param[in] playerId The ID of the player
 	//! \param[in] building The building entity to set as home
 	void SetHome(int playerId, IEntity building)
-	{	
+	{
+		// NEVER THE RAW ORIGIN. A building's origin is a point inside its shell, and this vector is
+		// persisted as the player's home - so storing it here is what respawned starting-house owners
+		// inside their own walls for the life of the save. HasSpawnPoints() gates the authored branch
+		// because GetSpawnPoint() falls back to that same origin when nothing is authored.
+		vector pos;
 		OVT_SpawnPointComponent spawn = OVT_SpawnPointComponent.Cast(building.FindComponent(OVT_SpawnPointComponent));
-		vector pos = building.GetOrigin();
-		if(spawn)
+		if(spawn && spawn.HasSpawnPoints())
 		{
 			pos = spawn.GetSpawnPoint();
 		}
+		else if(!OVT_WorldUtils.FindSpawnPositionOutside(building, pos))
+		{
+			pos = building.GetOrigin();
+		}
+
 		DoSetHome(playerId, pos);
-		Rpc(RpcDo_SetHome, playerId, pos);		
+		Rpc(RpcDo_SetHome, playerId, pos);
 	}
 	
 	//------------------------------------------------------------------------------------------------

--- a/Scripts/Game/GameMode/Managers/OVT_RecruitManagerComponent.c
+++ b/Scripts/Game/GameMode/Managers/OVT_RecruitManagerComponent.c
@@ -1221,7 +1221,7 @@ class OVT_RecruitManagerComponent : OVT_Component
 			vector forward = tent.GetWorldTransformAxis(2);
 			forward[1] = 0;
 
-			if (spawnPoint)
+			if (spawnPoint && spawnPoint.HasSpawnPoints())
 				anchor = spawnPoint.GetSpawnPoint();
 			else if (forward.Length() > 0.01)
 				anchor = tent.GetOrigin() + (forward.Normalized() * TENT_SPAWN_FORWARD_OFFSET);

--- a/Scripts/Game/Respawn/Logic/OVT_SpawnLogic.c
+++ b/Scripts/Game/Respawn/Logic/OVT_SpawnLogic.c
@@ -1229,13 +1229,19 @@ class OVT_SpawnLogic : SCR_SpawnLogic
 			if(!IsSpawnLocationSafe(housePos))
 				continue;
 
+			// HasSpawnPoints() gates this: without it GetSpawnPoint() answers with the building's own
+			// origin whenever the component authors nothing, which is the inside-the-shell vector this
+			// whole method exists to avoid.
 			OVT_SpawnPointComponent spawn = OVT_SpawnPointComponent.Cast(building.FindComponent(OVT_SpawnPointComponent));
-			if(spawn)
+			if(spawn && spawn.HasSpawnPoints())
 				return spawn.GetSpawnPoint();
 
-			// No authored point - search for a clear spot near the building, and skip the house
-			// entirely when there is none rather than hand back a position inside its shell.
+			// No authored point - stand them beside the building, and skip the house entirely when
+			// there is nowhere clear rather than hand back a position inside its shell.
 			vector clearPos;
+			if(OVT_WorldUtils.FindSpawnPositionOutside(building, clearPos))
+				return clearPos;
+
 			if(OVT_WorldUtils.TryFindSafeSpawnPosition(housePos, clearPos))
 				return clearPos;
 		}

--- a/Scripts/Game/Utilities/OVT_WorldUtils.c
+++ b/Scripts/Game/Utilities/OVT_WorldUtils.c
@@ -40,6 +40,162 @@ class OVT_WorldUtils : Managed
 	}
 	// Static array for spawn point search results
 	static ref array<IEntity> s_SpawnPointSearchResults;
+
+	//! How far above the standing surface a resolved spawn position is placed, so the character drops
+	//! onto the floor instead of starting fractionally inside it.
+	static const float SPAWN_GROUND_CLEARANCE = 0.5;
+
+	//! Ring radii used when the close-in probes are all inside whatever the caller is trying to get out
+	//! of. Deliberately short: a spawn that walks the player across the street is a nuisance, a spawn
+	//! that walks them across the town is a bug of its own.
+	static const ref array<float> SPAWN_RING_RADII = {4.0, 6.0, 8.0, 12.0};
+
+	//------------------------------------------------------------------------------------------------
+	//! The height a character standing at this XZ should have.
+	//!
+	//! GetSurfaceY answers for the TERRAIN ONLY, so any point sitting on something the terrain does not
+	//! know about - a building floor, a raised foundation, a concrete pad, a jetty - is dropped into
+	//! whatever is underneath it, which is the inside of the structure. Trace down through terrain AND
+	//! entities from just above the point instead, and keep GetSurfaceY as the answer when the trace
+	//! finds nothing (a point over a cliff edge, or one whose owner is floating).
+	//! \param[in] pos The position whose XZ is being resolved; its Y is the vertical search anchor.
+	//! \param[in] searchUp How far above pos to start the downward trace.
+	//! \param[in] searchDown How far below pos to give up.
+	//! \return The Y of the first surface found, else the terrain height.
+	static float ResolveGroundY(vector pos, float searchUp = 1.0, float searchDown = 3.0)
+	{
+		BaseWorld world = GetGame().GetWorld();
+		if (!world)
+			return pos[1];
+
+		TraceParam param = new TraceParam();
+		param.Start = pos + Vector(0, searchUp, 0);
+		param.End = pos - Vector(0, searchDown, 0);
+		param.Flags = TraceFlags.WORLD | TraceFlags.ENTS;
+
+		float travelled = world.TraceMove(param, null);
+		if (travelled < 1.0)
+			return param.Start[1] - ((searchUp + searchDown) * travelled);
+
+		return world.GetSurfaceY(pos[0], pos[2]);
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! Whether a body-sized box at this position is free of geometry.
+	//!
+	//! ENTS only, matching every other clearance test here: the box is placed clear of the surface, so
+	//! including terrain would make the ground itself read as an obstruction.
+	//! \param[in] pos The position to test.
+	//! \param[in] mins Box minimum corner, relative to pos.
+	//! \param[in] maxs Box maximum corner, relative to pos.
+	//! \param[in] exclude An entity the test should ignore - normally the thing the position belongs to.
+	//! \return True when nothing is in the way.
+	static bool IsPositionClear(vector pos, vector mins = "-0.5 0 -0.5", vector maxs = "0.5 2 0.5", IEntity exclude = null)
+	{
+		BaseWorld world = GetGame().GetWorld();
+		if (!world)
+			return true;
+
+		TraceBox trace = new TraceBox;
+		trace.Flags = TraceFlags.ENTS;
+		trace.Start = pos;
+		trace.Mins = mins;
+		trace.Maxs = maxs;
+		trace.Exclude = exclude;
+
+		return world.TracePosition(trace, null) >= 0;
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! Whether something solid is directly overhead.
+	//!
+	//! THE ONLY TEST THAT TELLS "inside a building" APART FROM "in the open". A clearance box cannot:
+	//! an empty room passes it exactly as a field does, which is why a gun dealer standing in somebody's
+	//! living room looked like a perfectly good placement to every check Overthrow had. Used to judge a
+	//! position that was MEANT to be outdoors - never to reject one that was deliberately put indoors.
+	//! \param[in] pos The standing position to test.
+	//! \param[in] height How far up to look.
+	//! \return True when the position is roofed.
+	static bool HasGeometryOverhead(vector pos, float height = 5.0)
+	{
+		BaseWorld world = GetGame().GetWorld();
+		if (!world)
+			return false;
+
+		TraceParam param = new TraceParam();
+		param.Start = pos + Vector(0, 0.5, 0);
+		param.End = pos + Vector(0, height, 0);
+		param.Flags = TraceFlags.ENTS;
+
+		return world.TraceMove(param, null) < 1.0;
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! A clear, grounded standing position just OUTSIDE a building's footprint.
+	//!
+	//! TryFindSafeSpawnPosition samples a 2 m sphere centred on what it is given, so anchoring it on a
+	//! building ORIGIN - a point inside the shell - answers with another point inside the shell, and an
+	//! open room passes the clearance test perfectly well. That is what puts gun dealers in living
+	//! rooms. This starts outside the entity's world bounds and rings outward instead.
+	//! \param[in] building The building to stand next to.
+	//! \param[out] foundPos A clear position outside it, or its origin when there is none.
+	//! \param[in] mins Clearance box minimum corner.
+	//! \param[in] maxs Clearance box maximum corner.
+	//! \return True when a clear position outside the footprint was found.
+	static bool FindSpawnPositionOutside(notnull IEntity building, out vector foundPos, vector mins = "-0.5 0 -0.5", vector maxs = "0.5 2 0.5")
+	{
+		foundPos = building.GetOrigin();
+
+		vector boundsMin, boundsMax;
+		building.GetWorldBounds(boundsMin, boundsMax);
+
+		vector centre = (boundsMin + boundsMax) * 0.5;
+		centre[1] = foundPos[1];
+
+		float footprint = Math.Max(boundsMax[0] - boundsMin[0], boundsMax[2] - boundsMin[2]) * 0.5;
+
+		vector firstClear;
+		bool haveClear = false;
+
+		for (int step = 0; step < 4; step++)
+		{
+			float radius = footprint + 2.0 + (step * 3.0);
+			for (int bearing = 0; bearing < 12; bearing++)
+			{
+				float angle = bearing * 30.0 * Math.DEG2RAD;
+				vector candidate = centre + Vector(Math.Sin(angle) * radius, 0, Math.Cos(angle) * radius);
+				candidate[1] = ResolveGroundY(Vector(candidate[0], centre[1], candidate[2])) + SPAWN_GROUND_CLEARANCE;
+
+				if (!IsPositionClear(candidate, mins, maxs))
+					continue;
+
+				if (!haveClear)
+				{
+					firstClear = candidate;
+					haveClear = true;
+				}
+
+				// OPEN SKY IS THE POINT, not merely a gap. A bounding box is quantized and can end short
+				// of a wing, an awning or a porch, so a "clear" candidate can still be under the very
+				// roof this is escaping - and a caller that re-judges its own recorded position would
+				// then move it again every session. Take a roofed spot only if nothing better exists.
+				if (!HasGeometryOverhead(candidate))
+				{
+					foundPos = candidate;
+					return true;
+				}
+			}
+		}
+
+		if (haveClear)
+		{
+			foundPos = firstClear;
+			return true;
+		}
+
+		return false;
+	}
+
 	static vector FindSafeSpawnPosition(vector pos, vector mins = "-0.5 0 -0.5", vector maxs = "0.5 2 0.5", bool skipSpawnPointSearch = false)
 	{
 		vector foundPos;
@@ -86,49 +242,61 @@ class OVT_WorldUtils : Managed
 				
 				if (closestEntity)
 				{
+					// HasSpawnPoints() first: GetSpawnPoint() falls back to the HOLDER'S OWN ORIGIN when
+					// nothing is authored, and for a building that is a point inside it - the exact
+					// answer this method exists to avoid. The clearance re-test is for the other half:
+					// an authored point can be blocked by something that was not there when it was
+					// authored (a placeable, a wreck, a neighbour's fence), and falling through to the
+					// probe below beats handing back a point we can see is occupied.
 					OVT_SpawnPointComponent spawnComp = OVT_SpawnPointComponent.Cast(closestEntity.FindComponent(OVT_SpawnPointComponent));
-					if (spawnComp)
+					if (spawnComp && spawnComp.HasSpawnPoints())
 					{
-						foundPos = spawnComp.GetSpawnPoint();
-						return true;
+						vector authored = spawnComp.GetSpawnPoint();
+						if (IsPositionClear(authored, mins, maxs))
+						{
+							foundPos = authored;
+							return true;
+						}
 					}
 				}
 			}
 		}
 
-		//a crude and brute-force way to find a spawn position, try to improve this later
-		int i = 0;
-		
-		BaseWorld world = GetGame().GetWorld();
-		float ground = world.GetSurfaceY(pos[0],pos[2]);
-		
+		// A crude random search close in, then rings outward. Every candidate is put ON the surface
+		// under it: the old code lifted the probe by a random 0-2 m from the INPUT's Y and traced ENTS
+		// only, so a candidate buried in a hillside or hanging two metres over it both read as clear
+		// (terrain is TraceFlags.WORLD, which the box test does not ask for) - that is a spawn in a
+		// wall wearing the disguise of a successful probe.
 		vector checkpos;
-		TraceBox trace;
-		while(i < 30)
+		for (int i = 0; i < 30; i++)
 		{
-			i++;
-			
-			//Get a random vector in a 2m radius sphere centered on pos and above the ground
-			checkpos = s_AIRandomGenerator.GenerateRandomPointInRadius(0,2,pos,false);
-			checkpos[1] = pos[1] + s_AIRandomGenerator.RandFloatXY(0, 2);
-						
-			//check if a box on that position collides with anything
-			trace = new TraceBox;
-			trace.Flags = TraceFlags.ENTS;
-			trace.Start = checkpos;
-			trace.Mins = mins;
-			trace.Maxs = maxs;
-			
-			float result = world.TracePosition(trace, null);
-				
-			if (result < 0)
+			//Get a random vector in a 2m radius sphere centered on pos, standing on whatever is under it
+			checkpos = s_AIRandomGenerator.GenerateRandomPointInRadius(0, 2, pos, false);
+			checkpos[1] = ResolveGroundY(Vector(checkpos[0], pos[1], checkpos[2])) + SPAWN_GROUND_CLEARANCE;
+
+			if (IsPositionClear(checkpos, mins, maxs))
 			{
-				//collision, try again
-				continue;
-			}else{
-				//no collision, this pos is safe
 				foundPos = checkpos;
 				return true;
+			}
+		}
+
+		// Still nothing: the 2 m sphere is inside the thing we are trying to get out of. Ring outward
+		// rather than hand back the colliding input - the same escape the vehicle path already has in
+		// FindVehicleSpawnNear, which the character path never got.
+		foreach (float radius : SPAWN_RING_RADII)
+		{
+			for (int bearing = 0; bearing < 8; bearing++)
+			{
+				float angle = bearing * 45.0 * Math.DEG2RAD;
+				checkpos = pos + Vector(Math.Sin(angle) * radius, 0, Math.Cos(angle) * radius);
+				checkpos[1] = ResolveGroundY(Vector(checkpos[0], pos[1], checkpos[2])) + SPAWN_GROUND_CLEARANCE;
+
+				if (IsPositionClear(checkpos, mins, maxs))
+				{
+					foundPos = checkpos;
+					return true;
+				}
 			}
 		}
 

--- a/docs/bugs/BUG-182.md
+++ b/docs/bugs/BUG-182.md
@@ -1,12 +1,17 @@
 ---
 id: BUG-182
 title: "Respawn choice spawns at the location's raw origin — OVT_SpawnPointComponent is never queried, so players materialise inside the FOB truck / building walls"
-status: open
+status: closed
 priority: high
 linkedFeature: map/respawn
 createdAt: 2026-08-18T00:00:00.000Z
-updatedAt: 2026-08-18T00:00:00.000Z
+updatedAt: 2026-08-26T00:00:00.000Z
 ---
+
+> **Closed 2026-08-26.** The fix described below landed in `283dee45 (fix) Respawn was not using
+> spawn points` and this record was simply never updated. The residual half — that the authored
+> point `TryFindSafeSpawnPosition` then returns was itself never validated, so a chosen location
+> could still spawn you in a wall — is [BUG-195](BUG-195.md).
 
 ## Symptom (player report, 2026-08-18)
 

--- a/docs/bugs/BUG-195.md
+++ b/docs/bugs/BUG-195.md
@@ -1,0 +1,122 @@
+---
+id: BUG-195
+title: "Spawn placement puts players in walls and gun dealers in living rooms — authored points are handed out unvalidated, heights come from the terrain only, and the fallback probe searches inside the building it is trying to escape"
+status: closed
+priority: high
+linkedFeature: map/respawn
+createdAt: 2026-08-26T00:00:00.000Z
+updatedAt: 2026-08-26T00:00:00.000Z
+---
+
+## Symptom (player report, 2026-08-26)
+
+Player spawns sometimes materialise inside walls, and every town's gun dealer stands **inside** a
+house rather than beside it. Reported as "the grid shifted after an update"; the causes below are all
+long-standing and were found by source reading, not by a version diff — a terrain/prefab change on
+BI's side may compound them but is neither necessary nor sufficient to produce either symptom.
+
+## Root causes
+
+Five defects, all in the shared spawn-placement path, so they stack.
+
+**1. `OVT_SpawnPointComponent.GetSpawnPoint()` handed out an authored point without ever testing it.**
+`m_aPoints.GetRandomElement()` picked one of the authored offsets blind. `OVT_BaseController.et`,
+`OverthrowMobileFOBDeployed.et`, `OVT_Camp.et` and `SignBusStop_01.et` each author four fixed offsets
+on all four sides of the owner; which of them is inside a wall, a fence or a neighbouring building
+depends entirely on where the owner was placed. The vehicle equivalent — `OVT_ParkingComponent.GetParkingSpot`
+— has always traced each spot and moved to the next on collision; the character path never did.
+
+**2. The same method forced the position onto the TERRAIN surface.**
+`GetSurfaceY(x, z) + 0.5` ignores anything the heightmap does not know about — a building floor, a
+raised foundation, a concrete pad — so a point authored on one was dropped into it. The authored Y
+offset (e.g. `0.2106` on `House_Village_E_1I04t.et`) was discarded outright.
+
+**3. `OVT_WorldUtils.TryFindSafeSpawnPosition()`'s probe could not see what it was testing for.**
+- `float ground = world.GetSurfaceY(...)` was computed and **never used** (already noted at
+  `OVT_RecruitManagerComponent.c:1202`).
+- The candidate height was `pos[1] + RandFloatXY(0, 2)` — relative to the input, so a probe could sit
+  two metres in the air or below the surface.
+- The clearance box traced `TraceFlags.ENTS` only. Terrain is `TraceFlags.WORLD`, so **a candidate
+  buried in a hillside read as clear.**
+- The 30 probes sampled a 2 m sphere **centred on the input**, i.e. inside the building the caller was
+  trying to get out of — and an empty room passes a box test perfectly well. The vehicle path grew
+  `FindVehicleSpawnNear` (rings at 8/12/16/22 m) for exactly this reason; the character path did not.
+
+**4. `GetSpawnPoint()`'s no-points fallback leaked through unguarded callers.**
+It returns the **owner's own origin** when nothing is authored — for a building, a point inside the
+shell. `HasSpawnPoints()` exists to gate that and was documented as the required check, but four call
+sites tested only `if (spawn)`: `OVT_WorldUtils.TryFindSafeSpawnPosition`, `OVT_SpawnLogic.FindSafeOwnedHouse`,
+`OVT_RealEstateManagerComponent.SetHome`, `OVT_TownCivilianSourceConfig`. (`OVT_HighCommandManagerComponent`
+was already correct.)
+
+**5. The gun dealer, specifically.**
+`OVT_TownController.SpawnGunDealer` anchors on a house **origin** and asks `FindSafeSpawnPosition` —
+defect 3 then answers with another point inside the same house. Two aggravating factors:
+- `GetRandomGunDealerHouse()` can never succeed: it queries `EQueryEntitiesFlags.STATIC` for an
+  `OVT_ShopComponent` of type `SHOP_GUNDEALER`, and **no building prefab carries that type** — the only
+  one that does is `Character_FIA_GunDealer.et`, which is not static. Every town therefore takes the
+  `GetRandomUnownedHouseInTown` fallback, i.e. an arbitrary house.
+- The result is written to `OVT_TownData.gunDealerPosition`, persisted by `OVT_TownManagerSerializer`
+  and **re-used verbatim on every subsequent session without revalidation** — so one bad placement
+  lasts the life of the campaign. That is why the symptom reads as permanent.
+  The reuse guard was also `gunDealerPosition[0] != 0`, the BUG-005 shape (a legitimate position with
+  X exactly 0 reads as unset).
+
+## Fix
+
+`Scripts/Game/Utilities/OVT_WorldUtils.c` — four new shared helpers:
+- `ResolveGroundY(pos, searchUp, searchDown)` — traces down through `WORLD | ENTS` to find the real
+  standing surface, falling back to `GetSurfaceY` when the trace finds nothing.
+- `IsPositionClear(pos, mins, maxs, exclude)` — the clearance box test, in one place.
+- `HasGeometryOverhead(pos, height)` — traces UP. This is the only test that separates "inside a
+  building" from "in the open": an empty room passes a clearance box exactly as a field does, which is
+  precisely why a dealer in somebody's living room read as a good placement to every check Overthrow
+  had. Used only to judge a position that was MEANT to be outdoors.
+- `FindSpawnPositionOutside(building, out pos, ...)` — rings outward from the entity's
+  `GetWorldBounds`, preferring a candidate with open sky and falling back to a merely-clear one, so
+  "next to the building" cannot resolve to "in the building" and a caller that re-judges its own
+  recorded position converges instead of moving it every session.
+
+`TryFindSafeSpawnPosition` now grounds every candidate through `ResolveGroundY`, re-tests an authored
+point before returning it, gates the spawn-point branch on `HasSpawnPoints()`, and rings out to
+4/6/8/12 m when the close-in probes all fail instead of returning the colliding input.
+
+`Scripts/Game/Components/OVT_SpawnPointComponent.c` — `GetSpawnPoint()` and `GetVehicleSpawnPoint()`
+walk the authored points from a random start index and return the first one that is clear (owner
+excluded), grounded through `ResolveGroundY`. Every point blocked still returns the first one, which
+is what the method always used to do.
+
+`Scripts/Game/Controllers/OVT_TownController.c` — `SpawnGunDealer` re-judges the persisted position
+against BOTH tests (blocked, or roofed) and re-resolves it when either fails, which is what moves an
+already-misplaced dealer out of the house on an existing save's next load. It also compares against
+`vector.Zero` and routes a house with no authored point through `FindSpawnPositionOutside`.
+
+`SetHome`, `FindSafeOwnedHouse`, `OVT_TownCivilianSourceConfig` and `OVT_RecruitManagerComponent` all
+gained the `HasSpawnPoints()` gate; the first two also prefer `FindSpawnPositionOutside` over the raw
+origin.
+
+## Verification
+
+Compile: Workbench `-wbsilent -validate` exit 0, Overthrow addon loaded, Game module 6351 files, zero
+in-project script errors (2026-08-26).
+
+Runtime acceptance is manual — no automated gate can see a position inside a wall:
+
+1. Start a fresh campaign; visit three towns' gun dealers → each stands outside the house, not in it.
+2. Load an EXISTING save whose dealer is inside a house → he moves out on the next session (the
+   revalidation path), and the map marker follows.
+3. Die and respawn at a base, a deployed FOB, a camp and an owned house → arrive at an authored point
+   that is clear, never inside geometry.
+4. Buy a starting house, `Set as home`, die, respawn at home → arrive beside the house.
+5. Fast-travel to a camp and to a house → vehicle and character both arrive clear.
+
+## Not fixed here
+
+`GetRandomGunDealerHouse()` is left in place. It is a no-op for the reason in cause 5 and always falls
+through, which is harmless; making it work means marking building prefabs `SHOP_GUNDEALER`, which is a
+content decision, not a bug fix.
+
+Whether an Arma Reforger update also moved the models under Overthrow's authored offsets is **not
+established** — the version-comparison tree (`N:\Projects\Arma 4\ArmaReforger.versions`) was not
+available on the machine this was investigated on. The vanilla prefab paths Overthrow overrides do
+still exist in the shipped `data` addon, so the overrides themselves resolve.


### PR DESCRIPTION
Players spawn inside walls and every town's gun dealer stands inside a house. Five defects in the shared spawn-placement path; they stack, and all of them predate any recent game update.

## Root causes

1. **`OVT_SpawnPointComponent.GetSpawnPoint()` never tested the point it handed out.** `m_aPoints.GetRandomElement()` picks blind.

## Verification

Workbench -validate: exit 0, zero in-project errors. Not play-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)