### PR TITLE
(feature) Add search box to Jobs menu, filtering by title and/or town

### DIFF
--- a/Language/localization_Overthrow.en-us.conf
+++ b/Language/localization_Overthrow.en-us.conf
@@ -1247,6 +1247,8 @@ StringTableRuntime {
   "OVT_Mission_Eden_Description"
   "OVT_Open_Overthrow_Menu"
   "OVT_Vehicle_Menu"
+  "OVT-JobsMenu_SearchLabel"
+  "OVT-Jobs_NoMatches"
  }
  Texts {
   "Account"
@@ -2544,5 +2546,7 @@ StringTableRuntime {
   "The persistent and dynamic revolution simulator"
   "Open Overthrow Menu"
   "Open Vehicle Menu"
+  "Search"
+  "No jobs match your search."
  }
 }

--- a/Language/localization_Overthrow.st
+++ b/Language/localization_Overthrow.st
@@ -24567,5 +24567,39 @@ StringTable {
    Author "Aaron Static"
    LastChanged "Lemmi"
   }
+  CustomStringTableItem "{00FB78163A7D6ED9}" {
+   Id "OVT-JobsMenu_SearchLabel"
+   Target_en_us "Search"
+   Comment "Label on the Jobs menu search box. The player types part of a job title here to filter the job list."
+   DevNote ""
+   Repro ""
+   ActorGender NONE
+   Terminology NONE
+   Status DEVELOPMENT_PENDING
+   NonTranslatable 0
+   MaxLength 0
+   Modified 1788562013
+   Author "Overthrow"
+   LastChanged "Overthrow"
+   ImageLink ""
+   Hidden 0
+  }
+  CustomStringTableItem "{3FE075E205F00400}" {
+   Id "OVT-Jobs_NoMatches"
+   Target_en_us "No jobs match your search."
+   Comment "Shown in the Jobs menu when the search text or town filter hides every job in the list."
+   DevNote ""
+   Repro ""
+   ActorGender NONE
+   Terminology NONE
+   Status DEVELOPMENT_PENDING
+   NonTranslatable 0
+   MaxLength 0
+   Modified 1788562013
+   Author "Overthrow"
+   LastChanged "Overthrow"
+   ImageLink ""
+   Hidden 0
+  }
  }
 }

--- a/Scripts/Game/UI/Components/OVT_JobListEntryHandler.c
+++ b/Scripts/Game/UI/Components/OVT_JobListEntryHandler.c
@@ -17,12 +17,17 @@ class OVT_JobListEntryHandler : SCR_ButtonBaseComponent
 		};
 		
 		TextWidget location = TextWidget.Cast(m_wRoot.FindAnyWidget("Location"));
-		if(job.townId == -1)
+		if(job.townId == -1 && job.baseId != -1)
 		{
 			OVT_BaseData base = OVT_Global.GetOccupyingFaction().m_Bases[job.baseId];
 			OVT_TownData town = OVT_Global.GetTowns().GetNearestTown(base.location);
 			int townID = OVT_Global.GetTowns().GetTownID(town);
 			location.SetText("#OVT-BaseNear " + OVT_Global.GetTowns().GetTownName(townID));
+		}else if(job.townId == -1)
+		{
+			// Neither a town job nor a base job (OVT_JobManagerComponent's "not tied to town/base"
+			// case) - there is no location to show.
+			location.SetText("");
 		}else{
 			location.SetText(OVT_Global.GetTowns().GetTownName(job.townId));
 		}

--- a/Scripts/Game/UI/Context/OVT_JobsContext.c
+++ b/Scripts/Game/UI/Context/OVT_JobsContext.c
@@ -2,18 +2,21 @@ class OVT_JobsContext : OVT_UIContext
 {
 	[Attribute(uiwidget: UIWidgets.ResourceNamePicker, desc: "Layout for job items", params: "layout")]
 	ResourceName m_JobLayout;
-	
+
 	OVT_JobManagerComponent m_JobManager;
 	OVT_Job m_SelectedJob;
 	OVT_JobConfig m_Selected
-		
+
+	//! Lowercased text typed into the search box. Empty means no text filter is active.
+	protected string m_sSearchFilter = "";
+
 	override void PostInit()
-	{		
+	{
 		m_JobManager = OVT_Global.GetJobs();
 	}
-	
+
 	override void OnShow()
-	{		
+	{
 		Widget closeButton = m_wRoot.FindAnyWidget("CloseButton");
 		if (closeButton)
 		{
@@ -21,26 +24,108 @@ class OVT_JobsContext : OVT_UIContext
 			if (action)
 				action.m_OnActivated.Insert(CloseLayout);
 		}
-		
+
 		Widget ww = m_wRoot.FindAnyWidget("ShowOnMap");
-		SCR_InputButtonComponent btn = SCR_InputButtonComponent.Cast(ww.FindHandler(SCR_InputButtonComponent));		
+		SCR_InputButtonComponent btn = SCR_InputButtonComponent.Cast(ww.FindHandler(SCR_InputButtonComponent));
 		btn.m_OnActivated.Insert(ShowOnMap);
-		
+
 		ww = m_wRoot.FindAnyWidget("Accept");
-		btn = SCR_InputButtonComponent.Cast(ww.FindHandler(SCR_InputButtonComponent));		
+		btn = SCR_InputButtonComponent.Cast(ww.FindHandler(SCR_InputButtonComponent));
 		btn.m_OnActivated.Insert(Accept);
-		
+
 		ww = m_wRoot.FindAnyWidget("Decline");
-		btn = SCR_InputButtonComponent.Cast(ww.FindHandler(SCR_InputButtonComponent));		
+		btn = SCR_InputButtonComponent.Cast(ww.FindHandler(SCR_InputButtonComponent));
 		btn.m_OnActivated.Insert(Decline);
-					
-		Refresh();		
+
+		BuildSearchBox();
+
+		Refresh();
 	}
-	
+
+	//------------------------------------------------------------------------------------------------
+	//! Wires the search box's live-change event. SCR_EditBoxComponent.m_OnChanged fires on every
+	//! keystroke, on-screen keyboard included, so a controller player typing with the pad keyboard
+	//! gets the same live filtering as a mouse-and-keyboard player.
+	protected void BuildSearchBox()
+	{
+		SCR_EditBoxComponent editBox = SCR_EditBoxComponent.GetEditBoxComponent("SearchBox", m_wRoot);
+		if(!editBox)
+			return;
+
+		editBox.m_OnChanged.Insert(OnSearchChanged);
+	}
+
+	//------------------------------------------------------------------------------------------------
+	protected void OnSearchChanged(SCR_EditBoxComponent comp, string value)
+	{
+		value.ToLower();
+		m_sSearchFilter = value;
+		m_SelectedJob = null;
+		Refresh();
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! A town job's effective town is its own townId. A base job has no townId of its own, so its
+	//! effective town is the town nearest the base - the same value the detail panel and the job
+	//! card both already show as the job's location. Some jobs (OVT_JobManagerComponent's "not tied
+	//! to town/base" case) have neither: townId == -1 AND baseId == -1. That is not an error, so
+	//! this returns -1 rather than indexing m_Bases with an invalid id. Callers must treat -1 as
+	//! "no town" and skip any GetTownName(-1) lookup, which would itself be out of range.
+	protected int GetEffectiveTownId(OVT_Job job)
+	{
+		if(job.townId != -1)
+			return job.townId;
+
+		if(job.baseId == -1)
+			return -1;
+
+		OVT_BaseData base = OVT_Global.GetOccupyingFaction().m_Bases[job.baseId];
+		if(!base)
+			return -1;
+
+		OVT_TownData town = OVT_Global.GetTowns().GetNearestTown(base.location);
+		return OVT_Global.GetTowns().GetTownID(town);
+	}
+
+	//------------------------------------------------------------------------------------------------
+	//! Clears the detail panel and hides its action buttons for the "filters hid every job" case.
+	//! Kept separate from the true-empty-job-list branch in Refresh, which has its own long-standing
+	//! (and unrelated) behaviour that this change does not touch.
+	protected void ShowNoMatchesPanel()
+	{
+		TextWidget title = TextWidget.Cast(m_wRoot.FindAnyWidget("SelectedJobName"));
+		if(title)
+			title.SetText("");
+
+		TextWidget location = TextWidget.Cast(m_wRoot.FindAnyWidget("SelectedLocation"));
+		if(location)
+			location.SetText("");
+
+		TextWidget details = TextWidget.Cast(m_wRoot.FindAnyWidget("SelectedDetails"));
+		if(details)
+			details.SetText("");
+
+		TextWidget desc = TextWidget.Cast(m_wRoot.FindAnyWidget("SelectedDescription"));
+		if(desc)
+			desc.SetText("#OVT-Jobs_NoMatches");
+
+		Widget w = m_wRoot.FindAnyWidget("ShowOnMap");
+		if(w)
+			w.SetVisible(false);
+
+		w = m_wRoot.FindAnyWidget("Accept");
+		if(w)
+			w.SetVisible(false);
+
+		w = m_wRoot.FindAnyWidget("Decline");
+		if(w)
+			w.SetVisible(false);
+	}
+
 	protected void Refresh()
 	{
 		Widget container = m_wRoot.FindAnyWidget("BrowserLayout");
-		
+
 		Widget child = container.GetChildren();
 		while(child)
 		{
@@ -48,46 +133,64 @@ class OVT_JobsContext : OVT_UIContext
 			child = container.GetChildren();
 		}
 
-		WorkspaceWidget workspace = GetGame().GetWorkspace(); 
-		
+		WorkspaceWidget workspace = GetGame().GetWorkspace();
+
 		if(m_JobManager.m_aJobs.Count() == 0)
 		{
 			TextWidget title = TextWidget.Cast(m_wRoot.FindAnyWidget("SelectedJobName"));
 			title.SetText("");
-			
+
 			TextWidget location = TextWidget.Cast(m_wRoot.FindAnyWidget("SelectedLocation"));
 			location.SetText("");
-			
+
 			TextWidget details = TextWidget.Cast(m_wRoot.FindAnyWidget("SelectedDetails"));
 			details.SetText("");
-			
+
 			TextWidget desc = TextWidget.Cast(m_wRoot.FindAnyWidget("SelectedDescription"));
 			desc.SetText("#OVT-Jobs_NoJobs");
-			
+
 			Widget w = m_wRoot.FindAnyWidget("ShowOnMap");
 			w.SetVisible(false);
-			
+
 			return;
 		}
-		
+
+		int shownCount = 0;
 		foreach(int i,OVT_Job job : m_JobManager.m_aJobs)
 		{
 			OVT_JobConfig config = m_JobManager.GetConfig(job.jobIndex);
-			if(job.owner != "" && job.owner != m_sPlayerID) continue;			
+			if(job.owner != "" && job.owner != m_sPlayerID) continue;
 			if(job.declined.Contains(m_sPlayerID)) continue;
-			
+			if(m_sSearchFilter != "")
+			{
+				string title = WidgetManager.Translate(config.m_sTitle);
+				title.ToLower();
+
+				string townName = "";
+				int effectiveTownId = GetEffectiveTownId(job);
+				if(effectiveTownId != -1)
+					townName = OVT_Global.GetTowns().GetTownName(effectiveTownId);
+				townName.ToLower();
+
+				if(title.IndexOf(m_sSearchFilter) == -1 && townName.IndexOf(m_sSearchFilter) == -1) continue;
+			}
+
 			Widget w = workspace.CreateWidgets(m_JobLayout, container);
-			
+
 			OVT_JobListEntryHandler handler = OVT_JobListEntryHandler.Cast(w.FindHandler(OVT_JobListEntryHandler));
-			
+
 			handler.Populate(job, config);
-			
+
 			handler.m_OnClicked.Insert(OnJobClicked);
 			if(!m_SelectedJob)
 			{
 				OnJobClicked(handler);
 			}
+			shownCount++;
 		}
+
+		if(shownCount == 0)
+			ShowNoMatchesPanel();
 	}
 	
 	protected void Accept()
@@ -140,10 +243,13 @@ class OVT_JobsContext : OVT_UIContext
 		TextWidget location = TextWidget.Cast(m_wRoot.FindAnyWidget("SelectedLocation"));
 		if(job.townId == -1)
 		{
-			OVT_BaseData base = OVT_Global.GetOccupyingFaction().m_Bases[job.baseId];
-			OVT_TownData town = OVT_Global.GetTowns().GetNearestTown(base.location);
-			int townID = OVT_Global.GetTowns().GetTownID(town);
-			location.SetText("#OVT-BaseNear " + OVT_Global.GetTowns().GetTownName(townID));
+			int effectiveTownId = GetEffectiveTownId(job);
+			if(effectiveTownId == -1)
+			{
+				location.SetText("");
+			}else{
+				location.SetText("#OVT-BaseNear " + OVT_Global.GetTowns().GetTownName(effectiveTownId));
+			}
 		}else{
 			location.SetText(OVT_Global.GetTowns().GetTownName(job.townId));
 		}

--- a/UI/Layouts/Menu/JobsMenu.layout
+++ b/UI/Layouts/Menu/JobsMenu.layout
@@ -104,6 +104,26 @@ FrameWidgetClass {
              Image ""
              Size 128 2
             }
+            HorizontalLayoutWidgetClass "{6B3D000000001001}" {
+             Name "FilterRow"
+             Slot LayoutSlot "{56EEDE07C9F827C2}" {
+              Padding 0 0 0 12
+             }
+             {
+              ButtonWidgetClass "{6B3D000000001002}" : "{0022F0B45ADBC5AC}UI/layouts/WidgetLibrary/EditBox/WLib_EditBox.layout" {
+               Name "SearchBox"
+               Slot LayoutSlot "{56F4D7D4EBB1BCF5}" {
+                SizeMode Fill
+               }
+               components {
+                SCR_EditBoxComponent "{547290FFBD5B33E9}" {
+                 m_sLabel "#OVT-JobsMenu_SearchLabel"
+                 m_bShowWriteIcon 0
+                }
+               }
+              }
+             }
+            }
             ScrollLayoutWidgetClass "{59A8D26AA9F807BD}" {
              Name "ContentSegment"
              Slot LayoutSlot "{59A8D25628A6B050}" {


### PR DESCRIPTION
Players can now type in the Jobs menu to narrow the job list by job title or by the town (or nearest town, for base jobs) it's located in. Also fixes a latent crash for jobs tied to neither a town nor a base, where the existing location-lookup code indexed the base array with -1.

This should be a nice QoL Improvement for playing on maps with a ton of towns/missions.

<img width="1807" height="900" alt="image" src="https://github.com/user-attachments/assets/cdecb71b-0d4b-43db-8eec-0678fa659ead" />